### PR TITLE
Fixed typographical error, changed accomdate to accommodate in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ All the functions can be seen in [examples/main.go](https://github.com/montanafl
 
 ### Contributing
 
-If you have any suggestions, criticism or bug reports please [create an issue](https://github.com/montanaflynn/stats/issues) and I'll do my best to accomdate you. Pull requests are much appreciated, you may want to read the [CONTRIBUTING.md](https://github.com/montanaflynn/stats/blob/master/CONTRIBUTING.md) document to ensure a seamless merge.
+If you have any suggestions, criticism or bug reports please [create an issue](https://github.com/montanaflynn/stats/issues) and I'll do my best to accommodate you. Pull requests are much appreciated, you may want to read the [CONTRIBUTING.md](https://github.com/montanaflynn/stats/blob/master/CONTRIBUTING.md) document to ensure a seamless merge.
 
 ### MIT License
 


### PR DESCRIPTION
montanaflynn, I've corrected a typographical error in the documentation of the [stats](https://github.com/montanaflynn/stats) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.