### PR TITLE
Realized the obvious efficiency gains of ignoring the unique numbers at the beginning of the slice.  Benchmark joy ensued.  

### DIFF
--- a/mode.go
+++ b/mode.go
@@ -21,7 +21,7 @@ func Mode(input Float64Data) (mode []float64, err error) {
 		switch {
 		case c[i] == c[i-1]:
 			cnt++
-		case cnt == maxCnt:
+		case cnt == maxCnt && maxCnt != 1:
 			mode = append(mode, c[i-1])
 			cnt = 1
 		case cnt > maxCnt:


### PR DESCRIPTION
This was nagging at me all day.  I just knew I had missed something that was staring me in the face.  The code was appending all of the unique numbers to `mode` until the first repeat occurrence.  All of that memory re-allocation to grow the slice was to blame for these speed-ups.

```
benchmark speed                        old ns/op     new ns/op     delta
BenchmarkModeSmallFloatSlice-8         475           470           -1.05%
BenchmarkModeSmallRandFloatSlice-8     367           362           -1.36%
BenchmarkModeLargeFloatSlice-8         3384996       955404        -71.78%
BenchmarkModeLargeRandFloatSlice-8     3440494       932409        -72.90%

benchmark alloc                        old allocs     new allocs     delta
BenchmarkModeSmallFloatSlice-8         4              4              +0.00%
BenchmarkModeSmallRandFloatSlice-8     3              3              +0.00%
BenchmarkModeLargeFloatSlice-8         28             3              -89.29%
BenchmarkModeLargeRandFloatSlice-8     28             3              -89.29%

benchmark memory                       old bytes     new bytes     delta
BenchmarkModeSmallFloatSlice-8         208           208           +0.00%
BenchmarkModeSmallRandFloatSlice-8     160           160           +0.00%
BenchmarkModeLargeFloatSlice-8         4626505       160           -100.00%
BenchmarkModeLargeRandFloatSlice-8     4626505       160           -100.00%
```