### PR TITLE
Adding ability to load quickly convert mixed-type data to Float64Data

### DIFF
--- a/load.go
+++ b/load.go
@@ -1,0 +1,35 @@
+package stats
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// LoadRawData parses and converts a slice of mixed data types to floats
+func LoadRawData(raw []interface{}) (f Float64Data) {
+	for _, v := range raw {
+		switch t := v.(type) {
+		case int:
+			a := float64(t)
+			f = append(f, a)
+		case uint:
+			f = append(f, float64(t))
+		case float64:
+			f = append(f, t)
+		case string:
+			fl, err := strconv.ParseFloat(t, 64)
+			if err != nil {
+				fmt.Println(err)
+			} else {
+				f = append(f, fl)
+			}
+		case bool:
+			if t == true {
+				f = append(f, 1.0)
+			} else {
+				f = append(f, 0.0)
+			}
+		}
+	}
+	return f
+}

--- a/load_test.go
+++ b/load_test.go
@@ -1,0 +1,50 @@
+package stats
+
+import "testing"
+
+var allTestData = []struct {
+	actual   []interface{}
+	expected Float64Data
+}{
+	{
+		[]interface{}{1.0, "2", 3.0, 4, "4.0", 5},
+		Float64Data{1.0, 2.0, 3.0, 4.0, 4.0, 5.0},
+	},
+	{
+		[]interface{}{"345", "223", "654.4", "194"},
+		Float64Data{345.0, 223.0, 654.4, 194.0},
+	},
+	{
+		[]interface{}{7862, 4234, 9872.1, 8794},
+		Float64Data{7862.0, 4234.0, 9872.1, 8794.0},
+	},
+	{
+		[]interface{}{true, false, true, false, false},
+		Float64Data{1.0, 0.0, 1.0, 0.0, 0.0},
+	},
+	{
+		[]interface{}{14.3, 26, 17.7, "shoe"},
+		Float64Data{14.3, 26.0, 17.7},
+	},
+}
+
+func equal(actual, expected Float64Data) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	for k, actualVal := range actual {
+		if actualVal != expected[k] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestLoadRawData(t *testing.T) {
+	for _, data := range allTestData {
+		actual := LoadRawData(data.actual)
+		if !equal(actual, data.expected) {
+			t.Fatalf("Transform(%v). Expected [%v], Actual [%v]", data.actual, data.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Simple example based off one provided on repository page.

	// start with the some source data to use
	raw := []interface{}{1.0, "2", 3.0, 4, "4.0", 5}

	// clean up raw data by converting to floats
	var data = stats.LoadRawData(raw)

	median, _ := stats.Median(data)
	fmt.Println(median) // 3.5

	roundedMedian, _ := stats.Round(median, 0)
	fmt.Println(roundedMedian) // 4