### PR TITLE
[percentile] prevent negative index

### DIFF
--- a/percentile.go
+++ b/percentile.go
@@ -24,7 +24,7 @@ func Percentile(input Float64Data, percent float64) (percentile float64, err err
 		// Find the average of the index and following values
 		percentile, _ = Mean(Float64Data{c[i-1], c[i]})
 
-	} else {
+	} else if index >= 1 {
 
 		// Convert float to int
 		i := float64ToInt(index)
@@ -32,6 +32,8 @@ func Percentile(input Float64Data, percent float64) (percentile float64, err err
 		// Find the value at the index
 		percentile = c[i-1]
 
+	} else {
+		return math.NaN(), BoundsErr
 	}
 
 	return percentile, nil

--- a/percentile_test.go
+++ b/percentile_test.go
@@ -26,6 +26,10 @@ func TestPercentile(t *testing.T) {
 	if err == nil {
 		t.Errorf("Zero percent didn't return an error")
 	}
+	_, err = Percentile([]float64{1, 2, 3, 4, 5}, 0.13)
+	if err == nil {
+		t.Errorf("Too low percent didn't return an error")
+	}
 }
 
 func TestPercentileSortSideEffects(t *testing.T) {


### PR DESCRIPTION
There is an error for too low percentiles.