### PR TITLE
add stable sampling

### DIFF
--- a/sample.go
+++ b/sample.go
@@ -1,6 +1,9 @@
 package stats
 
-import "math/rand"
+import (
+	"math/rand"
+	"sort"
+)
 
 // Sample returns sample from input with replacement or without
 func Sample(input Float64Data, takenum int, replacement bool) ([]float64, error) {
@@ -33,6 +36,35 @@ func Sample(input Float64Data, takenum int, replacement bool) ([]float64, error)
 
 		// Get element of input by permutated index
 		for _, idx := range perm[0:takenum] {
+			result = append(result, input[idx])
+		}
+
+		return result, nil
+
+	}
+
+	return nil, BoundsErr
+}
+
+// StableSample like stable sort, it returns samples from input while keeps the order of original data.
+func StableSample(input Float64Data, takenum int) ([]float64, error) {
+	if input.Len() == 0 {
+		return nil, EmptyInputErr
+	}
+
+	length := input.Len()
+
+	if takenum <= length {
+
+		rand.Seed(unixnano())
+
+		perm := rand.Perm(length)
+		perm = perm[0:takenum]
+		// Sort perm before applying
+		sort.Ints(perm)
+		result := Float64Data{}
+
+		for _, idx := range perm {
 			result = append(result, input[idx])
 		}
 

--- a/sample_test.go
+++ b/sample_test.go
@@ -7,12 +7,12 @@ import (
 func TestSample(t *testing.T) {
 	_, err := Sample([]float64{}, 10, false)
 	if err == nil {
-		t.Errorf("Returned an error")
+		t.Errorf("should return an error")
 	}
 
-	_, err2 := Sample([]float64{0.1, 0.2}, 10, false)
-	if err2 == nil {
-		t.Errorf("Returned an error")
+	_, err = Sample([]float64{0.1, 0.2}, 10, false)
+	if err == nil {
+		t.Errorf("should return an error")
 	}
 }
 
@@ -35,5 +35,33 @@ func TestSampleWithReplacement(t *testing.T) {
 	result, _ := Sample(arr, numsamples, true)
 	if len(result) != numsamples {
 		t.Errorf("%v != %v", len(result), numsamples)
+	}
+}
+
+func TestStableSample(t *testing.T) {
+	_, err := StableSample(Float64Data{}, 10)
+	if err != EmptyInputErr {
+		t.Errorf("should return EmptyInputError when sampling an empty data")
+	}
+	_, err = StableSample(Float64Data{1.0, 2.0}, 10)
+	if err != BoundsErr {
+		t.Errorf("should return BoundsErr when sampling size exceeds the maximum element size of data")
+	}
+	arr := []float64{1.0, 3.0, 2.0, -1.0, 5.0}
+	locations := map[float64]int{
+		1.0:  0,
+		3.0:  1,
+		2.0:  2,
+		-1.0: 3,
+		5.0:  4,
+	}
+	ret, _ := StableSample(arr, 3)
+	if len(ret) != 3 {
+		t.Errorf("returned wrong sample size")
+	}
+	for i := 1; i < 3; i++ {
+		if locations[ret[i]] < locations[ret[i-1]] {
+			t.Errorf("doesn't keep order")
+		}
 	}
 }


### PR DESCRIPTION
It turns out current `sample` function doesn't return the data as original order, it would shuffle the previous data. So here I provide a `stableSample` method, it samples the data and keep the order as well. Sometimes I found when I want use the `sample`, but also I would like keep the original order to see its trends. 

PTAL thanks.