### PR TITLE
Calculate quartiles with data from instance of float64data that already loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage.out
 release-notes.txt
 .directory
 .chglog
+.vscode

--- a/data.go
+++ b/data.go
@@ -162,3 +162,8 @@ func (f Float64Data) SoftMax() ([]float64, error) {
 func (f Float64Data) Entropy() (float64, error) {
 	return Entropy(f)
 }
+
+// Quartiles returns the three quartile points from instance of Float64Data
+func (f Float64Data) Quartiles() (Quartiles, error) {
+	return Quartile(f)
+}

--- a/data_test.go
+++ b/data_test.go
@@ -273,6 +273,6 @@ func BenchmarkMethodsAPI(b *testing.B) {
 func TestQuartilesMethods(t *testing.T) {
 	_, err := data1.Quartiles()
 	if err != nil {
-		t.Errorf("%s returned an error", getFunctionName(data1.Quartile))
+		t.Errorf("%s returned an error", getFunctionName(data1.Quartiles))
 	}
 }

--- a/data_test.go
+++ b/data_test.go
@@ -269,3 +269,10 @@ func BenchmarkMethodsAPI(b *testing.B) {
 		_, _ = data.Mode()
 	}
 }
+
+func TestQuartilesMethods(t *testing.T) {
+	_, err := data1.Quartiles()
+	if err != nil {
+		t.Errorf("%s returned an error", getFunctionName(data1.Quartile))
+	}
+}


### PR DESCRIPTION
PR for #60 

 Adding the Quartiles method on the Float64Data's struct without any input/argument, but use the current instance, like we use Mean(), Max(), etc. 