### PR TITLE
Add support for string and io.Reader for LoadRawData()

### DIFF
--- a/load.go
+++ b/load.go
@@ -1,7 +1,10 @@
 package stats
 
 import (
+	"bufio"
+	"io"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -153,6 +156,18 @@ func LoadRawData(raw interface{}) (f Float64Data) {
 	case map[int]time.Duration:
 		for i := 0; i < len(t); i++ {
 			r = append(r, t[i])
+		}
+	case string:
+		for _, v := range strings.Fields(t) {
+			r = append(r, v)
+		}
+	case io.Reader:
+		scanner := bufio.NewScanner(t)
+		for scanner.Scan() {
+			l := scanner.Text()
+			for _, v := range strings.Fields(l) {
+				r = append(r, v)
+			}
 		}
 	}
 

--- a/load_test.go
+++ b/load_test.go
@@ -2,6 +2,7 @@ package stats_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -149,6 +150,14 @@ var allTestData = []struct {
 	{
 		map[int]int64{0: -843, 1: 923, 2: -9223372036854775808, 3: 9223372036854775807, 4: 9223372036854775800},
 		stats.Float64Data{-843.0, 923.0, -9223372036854776000.0, 9223372036854776000.0, 9223372036854776000.0},
+	},
+	{
+		"1\n\n2 3.3\n  4.4",
+		stats.Float64Data{1.0, 2, 3.3, 4.4},
+	},
+	{
+		strings.NewReader("1\n\n2 3.3\n  4.4"),
+		stats.Float64Data{1.0, 2, 3.3, 4.4},
 	},
 }
 


### PR DESCRIPTION
Add support for a string and io.Reader in LoadRawData so it support whitespace separated strings.

ref #67
