### PR TITLE
fix: correct AutoCorrelation lag handling (#83)

### DIFF
--- a/correlation.go
+++ b/correlation.go
@@ -40,21 +40,26 @@ func AutoCorrelation(data Float64Data, lags int) (float64, error) {
 		return 0, EmptyInputErr
 	}
 
-	mean, _ := Mean(data)
-
-	var result, q float64
-
-	for i := 0; i < lags; i++ {
-		v := (data[0] - mean) * (data[0] - mean)
-		for i := 1; i < len(data); i++ {
-			delta0 := data[i-1] - mean
-			delta1 := data[i] - mean
-			q += (delta0*delta1 - q) / float64(i+1)
-			v += (delta1*delta1 - v) / float64(i+1)
-		}
-
-		result = q / v
+	if lags < 0 || lags >= len(data) {
+		return 0, BoundsErr
 	}
 
-	return result, nil
+	mean, _ := Mean(data)
+
+	var variance float64
+	for _, v := range data {
+		delta := v - mean
+		variance += delta * delta
+	}
+
+	if variance == 0 {
+		return 0, nil
+	}
+
+	var covariance float64
+	for i := lags; i < len(data); i++ {
+		covariance += (data[i] - mean) * (data[i-lags] - mean)
+	}
+
+	return covariance / variance, nil
 }

--- a/correlation_test.go
+++ b/correlation_test.go
@@ -79,4 +79,42 @@ func TestAutoCorrelation(t *testing.T) {
 	if err != stats.EmptyInputErr {
 		t.Errorf("Should have returned empty input error")
 	}
+
+	// Reference values cross-checked against statsmodels.tsa.stattools.acf,
+	// R acf(), and MATLAB autocorr (issue #83).
+	s3 := []float64{22, 24, 25, 25, 28, 29, 34, 37, 40, 44, 51, 48, 47, 50, 51}
+	expected := []float64{
+		1.0,
+		0.83174224,
+		0.65632458,
+		0.49105012,
+		0.27863962,
+		0.03102625,
+		-0.16527446,
+		-0.30369928,
+		-0.40095465,
+		-0.45823389,
+		-0.45047733,
+	}
+	for lag, want := range expected {
+		got, err := stats.AutoCorrelation(s3, lag)
+		if err != nil {
+			t.Errorf("AutoCorrelation(s3, %d) returned error: %v", lag, err)
+		}
+		if math.Abs(got-want) > 1e-8 {
+			t.Errorf("AutoCorrelation(s3, %d) = %v, want %v", lag, got, want)
+		}
+	}
+
+	if _, err := stats.AutoCorrelation(s1, -1); err != stats.BoundsErr {
+		t.Errorf("Should have returned bounds error for negative lag")
+	}
+	if _, err := stats.AutoCorrelation(s1, len(s1)); err != stats.BoundsErr {
+		t.Errorf("Should have returned bounds error for lag >= len(data)")
+	}
+
+	constant := []float64{3, 3, 3, 3, 3}
+	if a, err := stats.AutoCorrelation(constant, 1); err != nil || a != 0 {
+		t.Errorf("AutoCorrelation of constant series should be 0, got %v err=%v", a, err)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #83. The previous `AutoCorrelation` implementation misused the `lags` parameter as an outer loop counter instead of as the lag distance, and the inner loop was hardcoded to use `data[i-1]`/`data[i]` so it only ever computed lag-1 regardless of the requested lag. For `lags > 1` the result was a meaningless accumulation across iterations — exactly the symptom reported in the issue (`[0, 0.83, 0.89, 0.89, 0.89, ...]`).

The fix replaces it with the standard biased autocorrelation formula used by `statsmodels.tsa.stattools.acf`, R `acf()`, and MATLAB `autocorr`:

```
r_k = Σᵢ₌ₖ (xᵢ−μ)(xᵢ₋ₖ−μ) / Σᵢ (xᵢ−μ)²
```

Bounds checks added for negative lag and `lag >= len(data)`.

## Test plan

- [x] Regression test using the issue's reference series `[22, 24, 25, 25, 28, 29, 34, 37, 40, 44, 51, 48, 47, 50, 51]` with all 11 expected values for lags 0–10, cross-checked against statsmodels/R/MATLAB
- [x] Existing `TestAutoCorrelation` (lag 1 on `[1,2,3,4,5]` → 0.4) still passes
- [x] All 9 NIST StRD certified-value lag-1 tests still pass at original tolerances (down to 1e-14)
- [x] Bounds-error tests for negative lag and `lag >= len(data)`
- [x] Constant-series test for the zero-variance branch
- [x] 100% coverage maintained