### PR TITLE
Fix incorrect comments and error message for HarmonicMean

### DIFF
--- a/data.go
+++ b/data.go
@@ -39,7 +39,7 @@ func (f Float64Data) Mode() ([]float64, error) { return Mode(f) }
 // GeometricMean returns the median of the data
 func (f Float64Data) GeometricMean() (float64, error) { return GeometricMean(f) }
 
-// HarmonicMean returns the mode of the data
+// HarmonicMean returns the harmonic mean of the data
 func (f Float64Data) HarmonicMean() (float64, error) { return HarmonicMean(f) }
 
 // MedianAbsoluteDeviation the median of the absolute deviations from the dataset median

--- a/mean_test.go
+++ b/mean_test.go
@@ -82,7 +82,7 @@ func TestHarmonicMean(t *testing.T) {
 
 	hm, _ = stats.Round(hm, 2)
 	if hm != 2.19 {
-		t.Errorf("Geometric Mean %v != %v", hm, 2.19)
+		t.Errorf("Harmonic Mean %v != %v", hm, 2.19)
 	}
 
 	_, err = stats.HarmonicMean(s2)


### PR DESCRIPTION
## Summary

- Fix misleading error message in `mean_test.go`: `"Geometric Mean %v != %v"` → `"Harmonic Mean %v != %v"`
- Fix incorrect comment in `data.go`: `"HarmonicMean returns the mode of the data"` → `"HarmonicMean returns the harmonic mean of the data"`

These are copy-paste mistakes that make the code harder to understand and debug.