### PR TITLE
feat: add ArgMax, ArgMin and Range functions

### DIFF
--- a/describe.go
+++ b/describe.go
@@ -9,6 +9,7 @@ type Description struct {
 	Std                    float64
 	Max                    float64
 	Min                    float64
+	Range                  float64
 	DescriptionPercentiles []descriptionPercentile
 	AllowedNaN             bool
 }
@@ -39,6 +40,7 @@ func DescribePercentileFunc(input Float64Data, allowNaN bool, percentiles *[]flo
 	description.Std, _ = StandardDeviation(input)
 	description.Max, _ = Max(input)
 	description.Min, _ = Min(input)
+	description.Range, _ = Range(input)
 	description.Mean, _ = Mean(input)
 
 	if percentiles != nil {
@@ -60,6 +62,7 @@ Represents the Description instance in a string format with specified number of 
 	std     0.82
 	max     3.00
 	min     1.00
+	range   2.00
 	25.00%  NaN
 	50.00%  1.50
 	75.00%  2.50
@@ -73,6 +76,7 @@ func (d *Description) String(decimals int) string {
 	str += fmt.Sprintf("std\t%.*f\n", decimals, d.Std)
 	str += fmt.Sprintf("max\t%.*f\n", decimals, d.Max)
 	str += fmt.Sprintf("min\t%.*f\n", decimals, d.Min)
+	str += fmt.Sprintf("range\t%.*f\n", decimals, d.Range)
 	for _, percentile := range d.DescriptionPercentiles {
 		str += fmt.Sprintf("%.2f%%\t%.*f\n", percentile.Percentile, decimals, percentile.Value)
 	}

--- a/describe_test.go
+++ b/describe_test.go
@@ -27,7 +27,7 @@ func TestDescribeEmptyDatasetNaN(t *testing.T) {
 		t.Errorf("Returned an error")
 	}
 
-	if !math.IsNaN(describe.Max) || !math.IsNaN(describe.Mean) || !math.IsNaN(describe.Min) || !math.IsNaN(describe.Std) {
+	if !math.IsNaN(describe.Max) || !math.IsNaN(describe.Mean) || !math.IsNaN(describe.Min) || !math.IsNaN(describe.Range) || !math.IsNaN(describe.Std) {
 		t.Errorf("Was not NaN")
 	}
 }
@@ -38,7 +38,7 @@ func TestDescribeValidDatasetNaN(t *testing.T) {
 		t.Errorf("Returned an error")
 	}
 
-	if math.IsNaN(describe.Max) {
+	if math.IsNaN(describe.Max) || math.IsNaN(describe.Range) {
 		t.Errorf("Was NaN")
 	}
 }
@@ -64,6 +64,11 @@ func TestDescribeValues(t *testing.T) {
 		t.Errorf("Min was not equal to Min(dataset)")
 	}
 
+	rng, _ := stats.Range(dataSet)
+	if rng != describe.Range {
+		t.Errorf("Range was not equal to Range(dataset)")
+	}
+
 	mean, _ := stats.Mean(dataSet)
 	if mean != describe.Mean {
 		t.Errorf("Mean was not equal to Mean(dataset)")
@@ -77,7 +82,7 @@ func TestDescribeValues(t *testing.T) {
 
 func TestDescribeString(t *testing.T) {
 	describe, _ := stats.Describe([]float64{1.0, 2.0, 3.0}, true, &[]float64{25.0, 50.0, 75.0})
-	if describe.String(2) != "count\t3\nmean\t2.00\nstd\t0.82\nmax\t3.00\nmin\t1.00\n25.00%\t1.50\n50.00%\t2.00\n75.00%\t2.50\nNaN OK\ttrue" {
+	if describe.String(2) != "count\t3\nmean\t2.00\nstd\t0.82\nmax\t3.00\nmin\t1.00\nrange\t2.00\n25.00%\t1.50\n50.00%\t2.00\n75.00%\t2.50\nNaN OK\ttrue" {
 		t.Errorf("String output is not correct")
 	}
 }

--- a/extremes.go
+++ b/extremes.go
@@ -1,0 +1,72 @@
+package stats
+
+// ArgMax finds the index of the highest number in a slice,
+// returning the first occurrence in the case of ties
+func ArgMax(input Float64Data) (int, error) {
+
+	// Return an error if there are no numbers
+	if input.Len() == 0 {
+		return -1, ErrEmptyInput
+	}
+
+	// Track the index of the highest value seen so far
+	index := 0
+
+	// Loop and replace with strictly higher values only,
+	// which keeps the first occurrence on ties
+	for i := 1; i < input.Len(); i++ {
+		if input.Get(i) > input.Get(index) {
+			index = i
+		}
+	}
+
+	return index, nil
+}
+
+// ArgMin finds the index of the lowest number in a slice,
+// returning the first occurrence in the case of ties
+func ArgMin(input Float64Data) (int, error) {
+
+	// Return an error if there are no numbers
+	if input.Len() == 0 {
+		return -1, ErrEmptyInput
+	}
+
+	// Track the index of the lowest value seen so far
+	index := 0
+
+	// Loop and replace with strictly lower values only,
+	// which keeps the first occurrence on ties
+	for i := 1; i < input.Len(); i++ {
+		if input.Get(i) < input.Get(index) {
+			index = i
+		}
+	}
+
+	return index, nil
+}
+
+// Range finds the difference between the highest and
+// lowest numbers in a slice
+func Range(input Float64Data) (float64, error) {
+
+	// Return an error if there are no numbers
+	max, err := Max(input)
+	if err != nil {
+		return max, ErrEmptyInput
+	}
+
+	// Disregard error, since Max would have already returned it
+	min, _ := Min(input)
+
+	return max - min, nil
+}
+
+// ArgMax returns the index of the highest number in the data
+func (f Float64Data) ArgMax() (int, error) { return ArgMax(f) }
+
+// ArgMin returns the index of the lowest number in the data
+func (f Float64Data) ArgMin() (int, error) { return ArgMin(f) }
+
+// Range returns the difference between the highest and lowest numbers in the data
+func (f Float64Data) Range() (float64, error) { return Range(f) }

--- a/extremes_test.go
+++ b/extremes_test.go
@@ -1,0 +1,152 @@
+package stats_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExampleArgMax() {
+	d := []float64{1.1, 2.3, 3.2, 4.0, 4.01, 5.09}
+	a, _ := stats.ArgMax(d)
+	fmt.Println(a)
+	// Output: 5
+}
+
+func ExampleArgMin() {
+	d := []float64{1.1, 2.3, 3.2, 4.0, 4.01, 5.09}
+	a, _ := stats.ArgMin(d)
+	fmt.Println(a)
+	// Output: 0
+}
+
+func ExampleRange() {
+	d := []float64{4, 1, 9}
+	a, _ := stats.Range(d)
+	fmt.Println(a)
+	// Output: 8
+}
+
+func TestArgMax(t *testing.T) {
+	for _, c := range []struct {
+		in  []float64
+		out int
+	}{
+		{[]float64{1, 2, 3, 4, 5}, 4},
+		{[]float64{10.5, 3, 5, 7, 9}, 0},
+		{[]float64{-20, -1, -5.5}, 1},
+		{[]float64{-1.0}, 0},
+		{[]float64{1, 5, 2, 5}, 1},
+		{[]float64{7, 7, 7}, 0},
+	} {
+		got, err := stats.ArgMax(c.in)
+		if err != nil {
+			t.Errorf("Returned an error")
+		}
+		if got != c.out {
+			t.Errorf("ArgMax(%.1f) => %d != %d", c.in, got, c.out)
+		}
+	}
+	_, err := stats.ArgMax([]float64{})
+	if err != stats.ErrEmptyInput {
+		t.Errorf("Empty slice didn't return empty input error")
+	}
+}
+
+func TestArgMin(t *testing.T) {
+	for _, c := range []struct {
+		in  []float64
+		out int
+	}{
+		{[]float64{1, 2, 3, 4, 5}, 0},
+		{[]float64{10.5, 3, 5, 7, 9}, 1},
+		{[]float64{-20, -1, -5.5}, 0},
+		{[]float64{-1.0}, 0},
+		{[]float64{3, 1, 2, 1}, 1},
+		{[]float64{7, 7, 7}, 0},
+	} {
+		got, err := stats.ArgMin(c.in)
+		if err != nil {
+			t.Errorf("Returned an error")
+		}
+		if got != c.out {
+			t.Errorf("ArgMin(%.1f) => %d != %d", c.in, got, c.out)
+		}
+	}
+	_, err := stats.ArgMin([]float64{})
+	if err != stats.ErrEmptyInput {
+		t.Errorf("Empty slice didn't return empty input error")
+	}
+}
+
+func TestRange(t *testing.T) {
+	for _, c := range []struct {
+		in  []float64
+		out float64
+	}{
+		{[]float64{4, 1, 9}, 8.0},
+		{[]float64{1, 2, 3, 4, 5}, 4.0},
+		{[]float64{-20, -1, -5.5}, 19.0},
+		{[]float64{-1.0}, 0.0},
+		{[]float64{7, 7, 7}, 0.0},
+	} {
+		got, err := stats.Range(c.in)
+		if err != nil {
+			t.Errorf("Returned an error")
+		}
+		if got != c.out {
+			t.Errorf("Range(%.1f) => %.1f != %.1f", c.in, got, c.out)
+		}
+	}
+	_, err := stats.Range([]float64{})
+	if err != stats.ErrEmptyInput {
+		t.Errorf("Empty slice didn't return empty input error")
+	}
+}
+
+func TestFloat64DataArgMaxArgMinRangeMethods(t *testing.T) {
+	d := stats.Float64Data{1, 5, 2, 5}
+
+	argMax, err := d.ArgMax()
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if argMax != 1 {
+		t.Errorf("ArgMax method => %d != 1", argMax)
+	}
+
+	argMin, err := d.ArgMin()
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if argMin != 0 {
+		t.Errorf("ArgMin method => %d != 0", argMin)
+	}
+
+	rng, err := d.Range()
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if rng != 4.0 {
+		t.Errorf("Range method => %.1f != 4.0", rng)
+	}
+}
+
+func BenchmarkArgMaxSmallFloatSlice(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = stats.ArgMax(makeFloatSlice(5))
+	}
+}
+
+func BenchmarkArgMinSmallFloatSlice(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = stats.ArgMin(makeFloatSlice(5))
+	}
+}
+
+func BenchmarkRangeSmallFloatSlice(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = stats.Range(makeFloatSlice(5))
+	}
+}


### PR DESCRIPTION
Adds extremum locations (numpy `argmax`/`argmin`) and range (numpy `ptp`):

- `ArgMax(input)` / `ArgMin(input)` — index of the largest/smallest value; first occurrence wins on ties, matching numpy
- `Range(input)` — `Max - Min`, reusing the existing functions
- `Float64Data` method wrappers for all three
- `Describe` output now includes a `Range` field (also shown in `String`)

`ErrEmptyInput` on empty input. Input is never mutated.

## Test plan
- [x] Table-driven tests with explicit tie cases, Example functions, and benchmarks
- [x] Describe tests updated, including allowNaN/empty paths
- [x] `go test ./...` passes with 100% package coverage
