### PR TITLE
feat: add WeightedMean and CoefficientOfVariation

### DIFF
--- a/coefficient_of_variation.go
+++ b/coefficient_of_variation.go
@@ -1,0 +1,31 @@
+package stats
+
+import "math"
+
+// CoefficientOfVariation finds the coefficient of variation of a slice
+// of floats, defined as the sample standard deviation divided by the
+// mean. This matches the behavior of Python's scipy.stats.variation
+// with ddof=1.
+//
+// The input must not be empty and its mean must not be zero.
+func CoefficientOfVariation(input Float64Data) (float64, error) {
+	if input.Len() == 0 {
+		return math.NaN(), ErrEmptyInput
+	}
+
+	// Input is known to be non-empty so the mean and sample
+	// standard deviation cannot return an error
+	m, _ := Mean(input)
+	if m == 0 {
+		return math.NaN(), ErrZero
+	}
+
+	sd, _ := StandardDeviationSample(input)
+
+	return sd / m, nil
+}
+
+// CoefficientOfVariation finds the sample standard deviation divided by the mean
+func (f Float64Data) CoefficientOfVariation() (float64, error) {
+	return CoefficientOfVariation(f)
+}

--- a/coefficient_of_variation_test.go
+++ b/coefficient_of_variation_test.go
@@ -1,0 +1,45 @@
+package stats_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func TestCoefficientOfVariation(t *testing.T) {
+	// mean = 4, sample standard deviation = 2, so cv = 0.5
+	r, err := stats.CoefficientOfVariation(stats.Float64Data{2, 4, 6})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if math.Abs(r-0.5) > 0.0000001 {
+		t.Errorf("got %v, want ~0.5", r)
+	}
+}
+
+func TestCoefficientOfVariationEmptyInput(t *testing.T) {
+	_, err := stats.CoefficientOfVariation(stats.Float64Data{})
+	if err != stats.ErrEmptyInput {
+		t.Errorf("expected ErrEmptyInput, got %v", err)
+	}
+}
+
+func TestCoefficientOfVariationZeroMean(t *testing.T) {
+	_, err := stats.CoefficientOfVariation(stats.Float64Data{-1, 0, 1})
+	if err != stats.ErrZero {
+		t.Errorf("expected ErrZero for zero mean, got %v", err)
+	}
+}
+
+func TestFloat64DataCoefficientOfVariation(t *testing.T) {
+	data := stats.Float64Data{2, 4, 6}
+
+	r, err := data.CoefficientOfVariation()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if math.Abs(r-0.5) > 0.0000001 {
+		t.Errorf("got %v, want ~0.5", r)
+	}
+}

--- a/weighted_mean.go
+++ b/weighted_mean.go
@@ -1,0 +1,42 @@
+package stats
+
+import "math"
+
+// WeightedMean finds the weighted mean of a slice of floats, defined as
+// the sum of each data value multiplied by its weight divided by the sum
+// of all the weights. This matches the behavior of Python's
+// numpy.average with the weights argument.
+//
+// The data and weights slices must be the same length. Weights must be
+// non-negative and at least one weight must be positive.
+func WeightedMean(data, weights Float64Data) (float64, error) {
+	l := data.Len()
+	if l == 0 {
+		return math.NaN(), ErrEmptyInput
+	}
+
+	if weights.Len() != l {
+		return math.NaN(), ErrSize
+	}
+
+	weightedSum := 0.0
+	totalWeight := 0.0
+	for i := 0; i < l; i++ {
+		if weights[i] < 0 {
+			return math.NaN(), ErrNegative
+		}
+		weightedSum += data[i] * weights[i]
+		totalWeight += weights[i]
+	}
+
+	if totalWeight == 0 {
+		return math.NaN(), ErrZero
+	}
+
+	return weightedSum / totalWeight, nil
+}
+
+// WeightedMean finds the weighted mean of the data using the given weights
+func (f Float64Data) WeightedMean(weights Float64Data) (float64, error) {
+	return WeightedMean(f, weights)
+}

--- a/weighted_mean_test.go
+++ b/weighted_mean_test.go
@@ -1,0 +1,83 @@
+package stats_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func TestWeightedMean(t *testing.T) {
+	// (1*3 + 2*1 + 3*1) / (3 + 1 + 1) = 8 / 5 = 1.6
+	data := stats.Float64Data{1, 2, 3}
+	weights := stats.Float64Data{3, 1, 1}
+
+	r, err := stats.WeightedMean(data, weights)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r != 1.6 {
+		t.Errorf("got %v, want 1.6", r)
+	}
+}
+
+func TestWeightedMeanUniformWeights(t *testing.T) {
+	// With uniform weights the weighted mean should equal the mean
+	data := stats.Float64Data{1.5, 3.6, 7.9, 4.2}
+	weights := stats.Float64Data{2, 2, 2, 2}
+
+	r, err := stats.WeightedMean(data, weights)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m, err := stats.Mean(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if math.Abs(r-m) > 0.0000001 {
+		t.Errorf("got %v, want %v", r, m)
+	}
+}
+
+func TestWeightedMeanEmptyInput(t *testing.T) {
+	_, err := stats.WeightedMean(stats.Float64Data{}, stats.Float64Data{})
+	if err != stats.ErrEmptyInput {
+		t.Errorf("expected ErrEmptyInput, got %v", err)
+	}
+}
+
+func TestWeightedMeanSizeMismatch(t *testing.T) {
+	_, err := stats.WeightedMean(stats.Float64Data{1, 2}, stats.Float64Data{1})
+	if err != stats.ErrSize {
+		t.Errorf("expected ErrSize, got %v", err)
+	}
+}
+
+func TestWeightedMeanNegativeWeight(t *testing.T) {
+	_, err := stats.WeightedMean(stats.Float64Data{1, 2, 3}, stats.Float64Data{1, -1, 1})
+	if err != stats.ErrNegative {
+		t.Errorf("expected ErrNegative, got %v", err)
+	}
+}
+
+func TestWeightedMeanZeroWeights(t *testing.T) {
+	_, err := stats.WeightedMean(stats.Float64Data{1, 2, 3}, stats.Float64Data{0, 0, 0})
+	if err != stats.ErrZero {
+		t.Errorf("expected ErrZero for all-zero weights, got %v", err)
+	}
+}
+
+func TestFloat64DataWeightedMean(t *testing.T) {
+	data := stats.Float64Data{1, 2, 3}
+	weights := stats.Float64Data{3, 1, 1}
+
+	r, err := data.WeightedMean(weights)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r != 1.6 {
+		t.Errorf("got %v, want 1.6", r)
+	}
+}


### PR DESCRIPTION
Adds two commonly-needed summary statistics:

- `WeightedMean(data, weights)` — `Σ(dataᵢ·weightsᵢ) / Σ(weights)`, the numpy `np.average(weights=)` equivalent and natural companion to the existing `PercentileWeighted`
- `CoefficientOfVariation(input)` — sample standard deviation divided by the mean (scipy `variation` with ddof=1)
- `Float64Data` method wrappers for both

Errors: `ErrEmptyInput` on empty, `ErrSize` on length mismatch, `ErrNegative` on negative weights, `ErrZero` on zero weight sum / zero mean.

## Test plan
- [x] Value tests (uniform weights reproduce `Mean`; CV of {2,4,6} ≈ 0.5)
- [x] All error paths covered (empty, size mismatch, negative weight, zero weight sum, zero mean)
- [x] `go test ./...` passes with 100% package coverage
