### PR TITLE
feat: add ZScore and Rank functions

### DIFF
--- a/rank.go
+++ b/rank.go
@@ -1,0 +1,16 @@
+package stats
+
+// Rank assigns fractional (average) ranks to the input values.
+// Ranks are 1-based and tied values receive the average of the
+// ranks they would have been assigned.
+func Rank(input Float64Data) ([]float64, error) {
+	if input.Len() == 0 {
+		return nil, ErrEmptyInput
+	}
+	return rankData(input), nil
+}
+
+// Rank assigns fractional (average) ranks to the input values
+func (f Float64Data) Rank() ([]float64, error) {
+	return Rank(f)
+}

--- a/rank_test.go
+++ b/rank_test.go
@@ -1,0 +1,59 @@
+package stats_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExampleRank() {
+	r, _ := stats.Rank([]float64{3, 1, 4, 1})
+	fmt.Println(r)
+	// Output: [3 1.5 4 1.5]
+}
+
+func TestRank(t *testing.T) {
+	input := []float64{3, 1, 4, 1}
+	r, err := stats.Rank(input)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := []float64{3, 1.5, 4, 1.5}
+	for i, v := range expected {
+		if r[i] != v {
+			t.Errorf("%v != %v", r[i], v)
+		}
+	}
+
+	// Ensure the input slice was not mutated
+	original := []float64{3, 1, 4, 1}
+	for i, v := range original {
+		if input[i] != v {
+			t.Errorf("input was mutated: %v != %v", input[i], v)
+		}
+	}
+}
+
+func TestRankEmptyInput(t *testing.T) {
+	_, err := stats.Rank([]float64{})
+	if err != stats.ErrEmptyInput {
+		t.Errorf("expected ErrEmptyInput, got %v", err)
+	}
+}
+
+func TestFloat64DataRank(t *testing.T) {
+	d := stats.Float64Data{3, 1, 4, 1}
+	r, err := d.Rank()
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := []float64{3, 1.5, 4, 1.5}
+	for i, v := range expected {
+		if r[i] != v {
+			t.Errorf("%v != %v", r[i], v)
+		}
+	}
+}

--- a/zscore.go
+++ b/zscore.go
@@ -1,0 +1,29 @@
+package stats
+
+// ZScore standardizes the input values by subtracting the mean
+// and dividing by the sample standard deviation, returning the
+// number of standard deviations each value is from the mean.
+func ZScore(input Float64Data) ([]float64, error) {
+	if input.Len() == 0 {
+		return nil, ErrEmptyInput
+	}
+
+	m, _ := Mean(input)
+	sd, _ := StandardDeviationSample(input)
+
+	if sd == 0 {
+		return nil, ErrZero
+	}
+
+	z := make([]float64, len(input))
+	for i, v := range input {
+		z[i] = (v - m) / sd
+	}
+	return z, nil
+}
+
+// ZScore standardizes the input values by subtracting the mean
+// and dividing by the sample standard deviation
+func (f Float64Data) ZScore() ([]float64, error) {
+	return ZScore(f)
+}

--- a/zscore_test.go
+++ b/zscore_test.go
@@ -1,0 +1,66 @@
+package stats_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExampleZScore() {
+	z, _ := stats.ZScore([]float64{2, 4, 6})
+	fmt.Println(z)
+	// Output: [-1 0 1]
+}
+
+func TestZScore(t *testing.T) {
+	input := []float64{2, 4, 6}
+	z, err := stats.ZScore(input)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := []float64{-1, 0, 1}
+	for i, v := range expected {
+		if z[i] != v {
+			t.Errorf("%v != %v", z[i], v)
+		}
+	}
+
+	// Ensure the input slice was not mutated
+	original := []float64{2, 4, 6}
+	for i, v := range original {
+		if input[i] != v {
+			t.Errorf("input was mutated: %v != %v", input[i], v)
+		}
+	}
+}
+
+func TestZScoreZeroStandardDeviation(t *testing.T) {
+	_, err := stats.ZScore([]float64{5, 5, 5})
+	if err != stats.ErrZero {
+		t.Errorf("expected ErrZero, got %v", err)
+	}
+}
+
+func TestZScoreEmptyInput(t *testing.T) {
+	_, err := stats.ZScore([]float64{})
+	if err != stats.ErrEmptyInput {
+		t.Errorf("expected ErrEmptyInput, got %v", err)
+	}
+}
+
+func TestFloat64DataZScore(t *testing.T) {
+	d := stats.Float64Data{2, 4, 6}
+	z, err := d.ZScore()
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := []float64{-1, 0, 1}
+	for i, v := range expected {
+		if z[i] != v {
+			t.Errorf("%v != %v", z[i], v)
+		}
+	}
+}


### PR DESCRIPTION
Adds elementwise standardization (scipy `zscore`) and an exported ranking function:

- `ZScore(input)` — `(x - Mean) / StandardDeviationSample` per element
- `Rank(input)` — fractional (average) ranks, 1-based, ties get the mean of their positions; delegates to the existing unexported `rankData` already used by `Spearman`, so no logic is duplicated
- `Float64Data` method wrappers for both

Errors: `ErrEmptyInput` on empty; `ZScore` returns `ErrZero` for constant input (zero standard deviation). Input is never mutated; `correlation.go` is untouched.

## Test plan
- [x] `ZScore([2,4,6]) == [-1,0,1]`; `Rank([3,1,4,1]) == [3,1.5,4,1.5]` with tie behavior tested
- [x] Empty-input, zero-std, and no-mutation cases covered
- [x] `go test ./...` passes with 100% package coverage
