### PR TITLE
feat: add MovingAverage and MovingStdDev

### DIFF
--- a/rolling.go
+++ b/rolling.go
@@ -1,0 +1,65 @@
+package stats
+
+// MovingAverage calculates the rolling mean of the input over a trailing
+// window. Only fully-populated windows produce output, so the result has
+// len(input)-window+1 entries and entry i is the mean of input[i : i+window].
+// The window must satisfy 1 <= window <= len(input) or ErrBounds is
+// returned. An empty input returns ErrEmptyInput.
+func MovingAverage(input Float64Data, window int) ([]float64, error) {
+
+	if input.Len() == 0 {
+		return nil, ErrEmptyInput
+	}
+
+	if window < 1 || window > input.Len() {
+		return nil, ErrBounds
+	}
+
+	output := make([]float64, input.Len()-window+1)
+
+	for i := range output {
+		// Mean cannot fail here since every window is non-empty
+		mean, _ := Mean(input[i : i+window])
+		output[i] = mean
+	}
+
+	return output, nil
+}
+
+// MovingStdDev calculates the rolling sample standard deviation of the input
+// over a trailing window. Only fully-populated windows produce output, so the
+// result has len(input)-window+1 entries and entry i is the sample standard
+// deviation of input[i : i+window]. The window must satisfy
+// 2 <= window <= len(input) or ErrBounds is returned, since the sample
+// standard deviation of a single value is undefined. An empty input returns
+// ErrEmptyInput.
+func MovingStdDev(input Float64Data, window int) ([]float64, error) {
+
+	if input.Len() == 0 {
+		return nil, ErrEmptyInput
+	}
+
+	if window < 2 || window > input.Len() {
+		return nil, ErrBounds
+	}
+
+	output := make([]float64, input.Len()-window+1)
+
+	for i := range output {
+		// StandardDeviationSample cannot fail here since every window is non-empty
+		sdev, _ := StandardDeviationSample(input[i : i+window])
+		output[i] = sdev
+	}
+
+	return output, nil
+}
+
+// MovingAverage returns the rolling mean of the data over a trailing window
+func (f Float64Data) MovingAverage(window int) ([]float64, error) {
+	return MovingAverage(f, window)
+}
+
+// MovingStdDev returns the rolling sample standard deviation of the data over a trailing window
+func (f Float64Data) MovingStdDev(window int) ([]float64, error) {
+	return MovingStdDev(f, window)
+}

--- a/rolling_test.go
+++ b/rolling_test.go
@@ -1,0 +1,169 @@
+package stats_test
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExampleMovingAverage() {
+	data := []float64{1, 2, 3, 4, 5}
+	avg, _ := stats.MovingAverage(data, 3)
+	fmt.Println(avg)
+	// Output: [2 3 4]
+}
+
+func TestMovingAverage(t *testing.T) {
+	for _, c := range []struct {
+		in     []float64
+		window int
+		out    []float64
+	}{
+		{[]float64{1, 2, 3, 4, 5}, 3, []float64{2, 3, 4}},
+		{[]float64{1, 2, 3, 4, 5}, 1, []float64{1, 2, 3, 4, 5}},
+		{[]float64{1, 4, 9}, 2, []float64{2.5, 6.5}},
+	} {
+		got, err := stats.MovingAverage(c.in, c.window)
+		if err != nil {
+			t.Errorf("MovingAverage(%v, %d) returned an error", c.in, c.window)
+		}
+		if !reflect.DeepEqual(c.out, got) {
+			t.Errorf("MovingAverage(%v, %d) => %v != %v", c.in, c.window, got, c.out)
+		}
+	}
+}
+
+func TestMovingAverageFullWindowEqualsMean(t *testing.T) {
+	in := []float64{1.1, 2.2, 3.3, 4.4}
+	got, err := stats.MovingAverage(in, len(in))
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if len(got) != 1 {
+		t.Fatalf("Expected a single element, got %d", len(got))
+	}
+	mean, _ := stats.Mean(in)
+	if got[0] != mean {
+		t.Errorf("MovingAverage full window %v != Mean %v", got[0], mean)
+	}
+}
+
+func TestMovingAverageWindowOneCopiesInput(t *testing.T) {
+	in := []float64{5, 6, 7}
+	got, err := stats.MovingAverage(in, 1)
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if !reflect.DeepEqual(in, got) {
+		t.Errorf("MovingAverage(%v, 1) => %v != input", in, got)
+	}
+	got[0] = 99
+	if in[0] != 5 {
+		t.Errorf("MovingAverage(_, 1) must return a copy, not the input slice")
+	}
+}
+
+func TestMovingAverageInvalidInput(t *testing.T) {
+	_, err := stats.MovingAverage([]float64{}, 1)
+	if err != stats.ErrEmptyInput {
+		t.Errorf("Empty input should have returned ErrEmptyInput, got %v", err)
+	}
+	for _, window := range []int{0, -1, 4} {
+		_, err := stats.MovingAverage([]float64{1, 2, 3}, window)
+		if err != stats.ErrBounds {
+			t.Errorf("Window %d should have returned ErrBounds, got %v", window, err)
+		}
+	}
+}
+
+func ExampleMovingStdDev() {
+	data := []float64{1, 2, 3, 4}
+	sdev, _ := stats.MovingStdDev(data, 4)
+	fmt.Println(sdev)
+	// Output: [1.2909944487358056]
+}
+
+func TestMovingStdDev(t *testing.T) {
+	in := []float64{1, 2, 3, 4}
+	got, err := stats.MovingStdDev(in, 2)
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	want := []float64{0.7071, 0.7071, 0.7071}
+	if len(got) != len(want) {
+		t.Fatalf("Expected %d elements, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if math.Abs(got[i]-want[i]) > 0.0001 {
+			t.Errorf("MovingStdDev(%v, 2)[%d] => %v != %v", in, i, got[i], want[i])
+		}
+	}
+}
+
+func TestMovingStdDevFullWindowEqualsSample(t *testing.T) {
+	in := []float64{1.1, 2.2, 3.3, 4.4, 5.5}
+	got, err := stats.MovingStdDev(in, len(in))
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if len(got) != 1 {
+		t.Fatalf("Expected a single element, got %d", len(got))
+	}
+	sdev, _ := stats.StandardDeviationSample(in)
+	if got[0] != sdev {
+		t.Errorf("MovingStdDev full window %v != StandardDeviationSample %v", got[0], sdev)
+	}
+}
+
+func TestMovingStdDevInvalidInput(t *testing.T) {
+	_, err := stats.MovingStdDev([]float64{}, 2)
+	if err != stats.ErrEmptyInput {
+		t.Errorf("Empty input should have returned ErrEmptyInput, got %v", err)
+	}
+	for _, window := range []int{0, -1, 1, 4} {
+		_, err := stats.MovingStdDev([]float64{1, 2, 3}, window)
+		if err != stats.ErrBounds {
+			t.Errorf("Window %d should have returned ErrBounds, got %v", window, err)
+		}
+	}
+}
+
+func TestFloat64DataMovingAverage(t *testing.T) {
+	data := stats.Float64Data{1, 2, 3, 4, 5}
+	got, err := data.MovingAverage(3)
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if !reflect.DeepEqual([]float64{2, 3, 4}, got) {
+		t.Errorf("Float64Data.MovingAverage(3) => %v != [2 3 4]", got)
+	}
+}
+
+func TestFloat64DataMovingStdDev(t *testing.T) {
+	data := stats.Float64Data{1, 2, 3, 4}
+	got, err := data.MovingStdDev(4)
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	sdev, _ := stats.StandardDeviationSample(data)
+	if len(got) != 1 || got[0] != sdev {
+		t.Errorf("Float64Data.MovingStdDev(4) => %v != [%v]", got, sdev)
+	}
+}
+
+func BenchmarkMovingAverageSmallFloatSlice(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = stats.MovingAverage(makeFloatSlice(5), 3)
+	}
+}
+
+func BenchmarkMovingAverageLargeFloatSlice(b *testing.B) {
+	lf := makeFloatSlice(100000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = stats.MovingAverage(lf, 100)
+	}
+}


### PR DESCRIPTION
Adds rolling-window statistics (pandas `.rolling().mean()/.std()`, MATLAB `movmean`/`movstd`) with trailing, valid-only window semantics — output has `len(input) - window + 1` entries where entry `i` covers `input[i : i+window]`; no NaN padding:

- `MovingAverage(input, window)` — window must satisfy `1 <= window <= len(input)`
- `MovingStdDev(input, window)` — sample standard deviation (n−1, pandas default) per window; window must satisfy `2 <= window <= len(input)`
- `Float64Data` method wrappers for both

Errors: `ErrEmptyInput` on empty input, `ErrBounds` on invalid windows. Input is never mutated.

## Test plan
- [x] Value tests including window == 1 (copy), window == len (equals `Mean`/`StandardDeviationSample`)
- [x] All window-bounds error cases and empty input covered
- [x] `go test ./...` passes with 100% package coverage
