### PR TITLE
feat: add Clip and Rescale elementwise transforms

### DIFF
--- a/clip.go
+++ b/clip.go
@@ -1,0 +1,32 @@
+package stats
+
+// Clip clamps each value in the input slice into the
+// inclusive range between min and max.
+func Clip(input Float64Data, min, max float64) ([]float64, error) {
+	if input.Len() == 0 {
+		return nil, ErrEmptyInput
+	}
+
+	if min > max {
+		return nil, ErrBounds
+	}
+
+	c := make([]float64, len(input))
+	for i, v := range input {
+		switch {
+		case v < min:
+			c[i] = min
+		case v > max:
+			c[i] = max
+		default:
+			c[i] = v
+		}
+	}
+	return c, nil
+}
+
+// Clip clamps each value in the input slice into the
+// inclusive range between min and max.
+func (f Float64Data) Clip(min, max float64) ([]float64, error) {
+	return Clip(f, min, max)
+}

--- a/clip_test.go
+++ b/clip_test.go
@@ -1,0 +1,81 @@
+package stats_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExampleClip() {
+	c, _ := stats.Clip([]float64{1, 5, 10}, 2, 8)
+	fmt.Println(c)
+	// Output: [2 5 8]
+}
+
+func TestClip(t *testing.T) {
+	for _, c := range []struct {
+		in       []float64
+		min      float64
+		max      float64
+		expected []float64
+	}{
+		{[]float64{1, 5, 10}, 2, 8, []float64{2, 5, 8}},
+		{[]float64{-1, 0, 1}, 0, 0, []float64{0, 0, 0}},
+		{[]float64{3, 4}, 1, 10, []float64{3, 4}},
+	} {
+		got, err := stats.Clip(c.in, c.min, c.max)
+		if err != nil {
+			t.Error(err)
+		}
+		for i, v := range c.expected {
+			if got[i] != v {
+				t.Errorf("%v != %v", got[i], v)
+			}
+		}
+	}
+}
+
+func TestClipInputNotMutated(t *testing.T) {
+	input := []float64{1, 5, 10}
+	_, err := stats.Clip(input, 2, 8)
+	if err != nil {
+		t.Error(err)
+	}
+
+	original := []float64{1, 5, 10}
+	for i, v := range original {
+		if input[i] != v {
+			t.Errorf("input was mutated: %v != %v", input[i], v)
+		}
+	}
+}
+
+func TestClipInvalidBounds(t *testing.T) {
+	_, err := stats.Clip([]float64{1, 2, 3}, 8, 2)
+	if err != stats.ErrBounds {
+		t.Errorf("expected ErrBounds, got %v", err)
+	}
+}
+
+func TestClipEmptyInput(t *testing.T) {
+	_, err := stats.Clip([]float64{}, 0, 1)
+	if err != stats.ErrEmptyInput {
+		t.Errorf("expected ErrEmptyInput, got %v", err)
+	}
+}
+
+func TestFloat64DataClip(t *testing.T) {
+	d := stats.Float64Data{1, 5, 10}
+	c, err := d.Clip(2, 8)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := []float64{2, 5, 8}
+	for i, v := range expected {
+		if c[i] != v {
+			t.Errorf("%v != %v", c[i], v)
+		}
+	}
+}

--- a/rescale.go
+++ b/rescale.go
@@ -1,0 +1,29 @@
+package stats
+
+// Rescale normalizes the input values to the range of 0 to 1
+// by subtracting the minimum and dividing by the range,
+// also known as min-max normalization.
+func Rescale(input Float64Data) ([]float64, error) {
+	if input.Len() == 0 {
+		return nil, ErrEmptyInput
+	}
+
+	min, _ := Min(input)
+	max, _ := Max(input)
+
+	if max == min {
+		return nil, ErrZero
+	}
+
+	r := make([]float64, len(input))
+	for i, v := range input {
+		r[i] = (v - min) / (max - min)
+	}
+	return r, nil
+}
+
+// Rescale normalizes the input values to the range of 0 to 1
+// by subtracting the minimum and dividing by the range
+func (f Float64Data) Rescale() ([]float64, error) {
+	return Rescale(f)
+}

--- a/rescale_test.go
+++ b/rescale_test.go
@@ -1,0 +1,79 @@
+package stats_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExampleRescale() {
+	r, _ := stats.Rescale([]float64{2, 4, 6})
+	fmt.Println(r)
+	// Output: [0 0.5 1]
+}
+
+func TestRescale(t *testing.T) {
+	for _, c := range []struct {
+		in       []float64
+		expected []float64
+	}{
+		{[]float64{2, 4, 6}, []float64{0, 0.5, 1}},
+		{[]float64{10, 0}, []float64{1, 0}},
+		{[]float64{-2, 0, 2}, []float64{0, 0.5, 1}},
+	} {
+		got, err := stats.Rescale(c.in)
+		if err != nil {
+			t.Error(err)
+		}
+		for i, v := range c.expected {
+			if got[i] != v {
+				t.Errorf("%v != %v", got[i], v)
+			}
+		}
+	}
+}
+
+func TestRescaleInputNotMutated(t *testing.T) {
+	input := []float64{2, 4, 6}
+	_, err := stats.Rescale(input)
+	if err != nil {
+		t.Error(err)
+	}
+
+	original := []float64{2, 4, 6}
+	for i, v := range original {
+		if input[i] != v {
+			t.Errorf("input was mutated: %v != %v", input[i], v)
+		}
+	}
+}
+
+func TestRescaleConstantInput(t *testing.T) {
+	_, err := stats.Rescale([]float64{5, 5, 5})
+	if err != stats.ErrZero {
+		t.Errorf("expected ErrZero, got %v", err)
+	}
+}
+
+func TestRescaleEmptyInput(t *testing.T) {
+	_, err := stats.Rescale([]float64{})
+	if err != stats.ErrEmptyInput {
+		t.Errorf("expected ErrEmptyInput, got %v", err)
+	}
+}
+
+func TestFloat64DataRescale(t *testing.T) {
+	d := stats.Float64Data{2, 4, 6}
+	r, err := d.Rescale()
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := []float64{0, 0.5, 1}
+	for i, v := range expected {
+		if r[i] != v {
+			t.Errorf("%v != %v", r[i], v)
+		}
+	}
+}


### PR DESCRIPTION
Adds two elementwise transforms mirroring numpy `clip` and MATLAB `rescale`:

- `Clip(input, min, max)` — clamps each element into [min, max]; `ErrEmptyInput` on empty, `ErrBounds` if min > max
- `Rescale(input)` — min-max normalization to [0, 1]; `ErrEmptyInput` on empty, `ErrZero` on constant input (consistent with ZScore)

Both come with `Float64Data` method wrappers. Inputs are never mutated.

## Test plan

- [x] `ExampleClip`: Clip([1,5,10], 2, 8) = [2 5 8]
- [x] `ExampleRescale`: Rescale([2,4,6]) = [0 0.5 1]
- [x] min > max → ErrBounds; constant input → ErrZero; empty → ErrEmptyInput
- [x] Input-mutation assertions for both
- [x] `go test ./...` passes, package coverage 100.0%, gofmt clean