### PR TITLE
feat: add Kurtosis, PopulationKurtosis, and SampleKurtosis

### DIFF
--- a/kurtosis.go
+++ b/kurtosis.go
@@ -1,0 +1,70 @@
+package stats
+
+import "math"
+
+// Kurtosis computes the population excess kurtosis of the dataset
+func Kurtosis(input Float64Data) (float64, error) {
+	return PopulationKurtosis(input)
+}
+
+// PopulationKurtosis computes the population excess kurtosis (Fisher
+// definition) using the fourth central moment normalized by the squared
+// variance, so a normal distribution has a kurtosis of zero.
+func PopulationKurtosis(input Float64Data) (float64, error) {
+	if input.Len() < 2 {
+		return math.NaN(), ErrEmptyInput
+	}
+
+	mean, _ := Mean(input)
+
+	// Compute sums of squared and fourth-power differences from the mean
+	var sumOfSquares, sumOfFourths float64
+	for _, v := range input {
+		d := v - mean
+		d2 := d * d
+		sumOfSquares += d2
+		sumOfFourths += d2 * d2
+	}
+
+	if sumOfSquares == 0 {
+		return math.NaN(), ErrZero
+	}
+
+	n := float64(input.Len())
+	variance := sumOfSquares / n
+
+	return (sumOfFourths/n)/(variance*variance) - 3.0, nil
+}
+
+// SampleKurtosis computes the bias-corrected sample excess kurtosis,
+// matching pandas .kurt() and scipy.stats.kurtosis with bias=False.
+func SampleKurtosis(input Float64Data) (float64, error) {
+	n := input.Len()
+	if n < 4 {
+		return math.NaN(), ErrEmptyInput
+	}
+
+	g2, err := PopulationKurtosis(input)
+	if err != nil {
+		return math.NaN(), err
+	}
+
+	// Bias-corrected: G2 = ((n+1)*g2 + 6) * (n-1) / ((n-2)*(n-3))
+	nf := float64(n)
+	return ((nf+1)*g2 + 6) * (nf - 1) / ((nf - 2) * (nf - 3)), nil
+}
+
+// Kurtosis finds the population excess kurtosis of a slice of floats
+func (f Float64Data) Kurtosis() (float64, error) {
+	return Kurtosis(f)
+}
+
+// PopulationKurtosis finds the population excess kurtosis of a slice of floats
+func (f Float64Data) PopulationKurtosis() (float64, error) {
+	return PopulationKurtosis(f)
+}
+
+// SampleKurtosis finds the bias-corrected sample excess kurtosis of a slice of floats
+func (f Float64Data) SampleKurtosis() (float64, error) {
+	return SampleKurtosis(f)
+}

--- a/kurtosis_test.go
+++ b/kurtosis_test.go
@@ -1,0 +1,165 @@
+package stats_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+// Reference values verified against scipy.stats.kurtosis and pandas .kurt()
+var kurtosisTests = []struct {
+	name string
+	data stats.Float64Data
+}{
+	{"RightSkewed", stats.Float64Data{1, 2, 2, 3, 9}},
+	{"LeftSkewed", stats.Float64Data{9, 8, 8, 7, 1}},
+	{"Symmetric", stats.Float64Data{2, 4, 6, 8, 10}},
+	{"UniformRange", stats.Float64Data{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+	{"HeavilyRightSkewed", stats.Float64Data{1, 1, 1, 1, 1, 1, 1, 1, 1, 100}},
+}
+
+func TestKurtosis(t *testing.T) {
+	// scipy.stats.kurtosis(data, fisher=True, bias=True)
+	expected := []float64{
+		0.017296634932605137,
+		0.017296634932604391,
+		-1.3,
+		-1.2242424242424241,
+		5.1111111111111107,
+	}
+
+	for i, tt := range kurtosisTests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := stats.Kurtosis(tt.data)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !close(got, expected[i]) {
+				t.Errorf("got %v, want %v", got, expected[i])
+			}
+		})
+	}
+}
+
+func TestPopulationKurtosis(t *testing.T) {
+	// scipy.stats.kurtosis(data, fisher=True, bias=True)
+	expected := []float64{
+		0.017296634932605137,
+		0.017296634932604391,
+		-1.3,
+		-1.2242424242424241,
+		5.1111111111111107,
+	}
+
+	for i, tt := range kurtosisTests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := stats.PopulationKurtosis(tt.data)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !close(got, expected[i]) {
+				t.Errorf("got %v, want %v", got, expected[i])
+			}
+		})
+	}
+}
+
+func TestSampleKurtosis(t *testing.T) {
+	// pandas .kurt() / scipy.stats.kurtosis(data, fisher=True, bias=False)
+	expected := []float64{
+		4.0691865397304179,
+		4.0691865397304179,
+		-1.2,
+		-1.2,
+		10.0,
+	}
+
+	for i, tt := range kurtosisTests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := stats.SampleKurtosis(tt.data)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !close(got, expected[i]) {
+				t.Errorf("got %v, want %v", got, expected[i])
+			}
+		})
+	}
+}
+
+func TestKurtosis_Methods(t *testing.T) {
+	data := stats.Float64Data{1, 2, 3, 4, 5}
+
+	got, err := data.Kurtosis()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !close(got, -1.3) {
+		t.Errorf("Kurtosis got %v, want %v", got, -1.3)
+	}
+
+	got, err = data.PopulationKurtosis()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !close(got, -1.3) {
+		t.Errorf("PopulationKurtosis got %v, want %v", got, -1.3)
+	}
+
+	got, err = data.SampleKurtosis()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !close(got, -1.2) {
+		t.Errorf("SampleKurtosis got %v, want %v", got, -1.2)
+	}
+}
+
+func TestKurtosis_ZeroVariance(t *testing.T) {
+	for _, fn := range []func(stats.Float64Data) (float64, error){
+		stats.Kurtosis, stats.PopulationKurtosis, stats.SampleKurtosis,
+	} {
+		_, err := fn(stats.Float64Data{5, 5, 5, 5})
+		if err != stats.ErrZero {
+			t.Fatalf("expected ErrZero for zero variance, got %v", err)
+		}
+	}
+}
+
+func TestKurtosis_EmptyInput(t *testing.T) {
+	for _, fn := range []func(stats.Float64Data) (float64, error){
+		stats.Kurtosis, stats.PopulationKurtosis, stats.SampleKurtosis,
+	} {
+		_, err := fn(stats.Float64Data{})
+		if err != stats.ErrEmptyInput {
+			t.Fatalf("expected ErrEmptyInput for empty input, got %v", err)
+		}
+	}
+}
+
+func TestKurtosis_TooSmallDataset(t *testing.T) {
+	_, err := stats.Kurtosis(stats.Float64Data{42})
+	if err != stats.ErrEmptyInput {
+		t.Fatalf("expected ErrEmptyInput for dataset length < 2, got %v", err)
+	}
+}
+
+func TestSampleKurtosis_TooSmallDataset(t *testing.T) {
+	_, err := stats.SampleKurtosis(stats.Float64Data{1, 2, 3})
+	if err != stats.ErrEmptyInput {
+		t.Fatalf("expected ErrEmptyInput for dataset length < 4, got %v", err)
+	}
+}
+
+func ExampleKurtosis() {
+	k, _ := stats.Kurtosis([]float64{1, 2, 3, 4, 5})
+	fmt.Println(k)
+	// Output: -1.3
+}
+
+func ExampleSampleKurtosis() {
+	k, _ := stats.SampleKurtosis([]float64{1, 2, 3, 4, 5})
+	fmt.Printf("%.1f\n", k)
+	// Output: -1.2
+}


### PR DESCRIPTION
Adds the fourth-moment siblings of the skewness family. All three return excess kurtosis (Fisher definition: normal = 0), matching pandas `.kurt()` and scipy `kurtosis(fisher=True)`:

- `PopulationKurtosis` — biased estimator g2 = m4/m2² − 3
- `SampleKurtosis` — bias-corrected G2 (pandas / scipy `bias=False`), requires n ≥ 4
- `Kurtosis` — delegates to PopulationKurtosis, mirroring how `Skewness` delegates

Method wrappers for all three. Zero variance returns `ErrZero`; too-small n and empty input return `ErrEmptyInput`, matching the skewness family.

## Test plan

- [x] `PopulationKurtosis([1,2,3,4,5])` = −1.3 (exact, uniform data)
- [x] `SampleKurtosis([1,2,3,4,5])` = −1.2, matching pandas `.kurt()`
- [x] Reference values verified against scipy in both bias modes
- [x] Zero variance → ErrZero; n too small / empty → ErrEmptyInput
- [x] `go test ./...` passes, package coverage 100.0%, gofmt clean