### PR TITLE
feat: add TrimmedMean and Winsorize robust statistics

### DIFF
--- a/trimmed_mean.go
+++ b/trimmed_mean.go
@@ -1,0 +1,38 @@
+package stats
+
+import "math"
+
+// TrimmedMean finds the mean of a slice of floats after removing a
+// fraction of the smallest and largest values. This matches the
+// behavior of Python's scipy.stats.trim_mean.
+//
+// The percent parameter is the fraction removed from each tail and
+// must be in the range [0, 0.5). The number of elements trimmed from
+// each tail is floor(len(input) * percent). A percent of zero returns
+// the same result as Mean.
+func TrimmedMean(input Float64Data, percent float64) (float64, error) {
+	l := input.Len()
+	if l == 0 {
+		return math.NaN(), ErrEmptyInput
+	}
+
+	// Reject percents outside [0, 0.5) including NaN. Since percent is
+	// strictly below 0.5 at least one element always remains after
+	// trimming floor(l * percent) elements from each tail.
+	if !(percent >= 0 && percent < 0.5) {
+		return math.NaN(), ErrBounds
+	}
+
+	sorted := sortedCopy(input)
+
+	// Number of elements removed from each tail
+	k := int(math.Floor(float64(l) * percent))
+
+	return Mean(sorted[k : l-k])
+}
+
+// TrimmedMean finds the mean of the data after removing a fraction of
+// the smallest and largest values from each tail
+func (f Float64Data) TrimmedMean(percent float64) (float64, error) {
+	return TrimmedMean(f, percent)
+}

--- a/trimmed_mean_test.go
+++ b/trimmed_mean_test.go
@@ -1,0 +1,96 @@
+package stats_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExampleTrimmedMean() {
+	tm, _ := stats.TrimmedMean([]float64{1, 2, 3, 4, 100}, 0.2)
+	fmt.Println(tm)
+	// Output: 3
+}
+
+func TestTrimmedMean(t *testing.T) {
+	for _, c := range []struct {
+		in      []float64
+		percent float64
+		out     float64
+	}{
+		{[]float64{1, 2, 3, 4, 100}, 0.2, 3.0},
+		// Verified against scipy.stats.trim_mean
+		{[]float64{4.2, 1.1, 9.9, 3.3, 2.7, 8.8, 5.5, 7.4, 6.6, 100.5}, 0.2, 5.966666666666666},
+		{[]float64{1, 2, 3, 4, 5}, 0.1, 3.0},
+		{[]float64{1, 2, 3, 4, 5, 6}, 0.25, 3.5},
+		{[]float64{5}, 0.4, 5.0},
+	} {
+		got, err := stats.TrimmedMean(c.in, c.percent)
+		if err != nil {
+			t.Errorf("TrimmedMean(%v, %v) returned an error: %v", c.in, c.percent, err)
+		}
+		if math.Abs(got-c.out) > 1e-12 {
+			t.Errorf("TrimmedMean(%v, %v) => %v != %v", c.in, c.percent, got, c.out)
+		}
+	}
+}
+
+func TestTrimmedMeanZeroPercentEqualsMean(t *testing.T) {
+	data := []float64{-2.5, 7.5, 1.25, 4.75}
+	tm, err := stats.TrimmedMean(data, 0)
+	if err != nil {
+		t.Errorf("Should not have returned an error: %v", err)
+	}
+	mean, _ := stats.Mean(data)
+	if tm != mean {
+		t.Errorf("TrimmedMean(%v, 0) => %v != Mean %v", data, tm, mean)
+	}
+}
+
+func TestTrimmedMeanInvalidInput(t *testing.T) {
+	tm, err := stats.TrimmedMean([]float64{}, 0.1)
+	if err != stats.ErrEmptyInput {
+		t.Errorf("Expected ErrEmptyInput, got %v", err)
+	}
+	if !math.IsNaN(tm) {
+		t.Errorf("Expected NaN, got %v", tm)
+	}
+
+	for _, percent := range []float64{-0.1, 0.5, 1.0, math.NaN()} {
+		tm, err = stats.TrimmedMean([]float64{1, 2, 3}, percent)
+		if err != stats.ErrBounds {
+			t.Errorf("TrimmedMean percent %v expected ErrBounds, got %v", percent, err)
+		}
+		if !math.IsNaN(tm) {
+			t.Errorf("TrimmedMean percent %v expected NaN, got %v", percent, tm)
+		}
+	}
+}
+
+func TestTrimmedMeanDoesNotMutateInput(t *testing.T) {
+	data := []float64{100, 1, 4, 2, 3}
+	_, err := stats.TrimmedMean(data, 0.2)
+	if err != nil {
+		t.Errorf("Should not have returned an error: %v", err)
+	}
+	want := []float64{100, 1, 4, 2, 3}
+	for i := range want {
+		if data[i] != want[i] {
+			t.Errorf("Input was mutated: %v != %v", data, want)
+			break
+		}
+	}
+}
+
+func TestFloat64DataTrimmedMean(t *testing.T) {
+	data := stats.Float64Data{1, 2, 3, 4, 100}
+	tm, err := data.TrimmedMean(0.2)
+	if err != nil {
+		t.Errorf("Should not have returned an error: %v", err)
+	}
+	if tm != 3.0 {
+		t.Errorf("TrimmedMean(0.2) => %v != 3", tm)
+	}
+}

--- a/winsorize.go
+++ b/winsorize.go
@@ -1,0 +1,50 @@
+package stats
+
+import "math"
+
+// Winsorize limits the effect of outliers in a slice of floats by
+// clamping a fraction of the smallest and largest values. This matches
+// the behavior of Python's scipy.stats.mstats.winsorize with symmetric
+// limits.
+//
+// The percent parameter is the fraction clamped in each tail and must
+// be in the range [0, 0.5). With k = floor(len(input) * percent),
+// values below the k-th smallest value are set to it and values above
+// the k-th largest value are set to it. The returned slice preserves
+// the original element order and a percent of zero returns a copy of
+// the input.
+func Winsorize(input Float64Data, percent float64) ([]float64, error) {
+	l := input.Len()
+	if l == 0 {
+		return nil, ErrEmptyInput
+	}
+
+	// Reject percents outside [0, 0.5) including NaN
+	if !(percent >= 0 && percent < 0.5) {
+		return nil, ErrBounds
+	}
+
+	sorted := sortedCopy(input)
+
+	// Number of elements clamped in each tail
+	k := int(math.Floor(float64(l) * percent))
+	lower := sorted[k]
+	upper := sorted[l-1-k]
+
+	output := copyslice(input)
+	for i, v := range output {
+		if v < lower {
+			output[i] = lower
+		} else if v > upper {
+			output[i] = upper
+		}
+	}
+
+	return output, nil
+}
+
+// Winsorize returns a copy of the data with a fraction of the smallest
+// and largest values in each tail clamped
+func (f Float64Data) Winsorize(percent float64) ([]float64, error) {
+	return Winsorize(f, percent)
+}

--- a/winsorize_test.go
+++ b/winsorize_test.go
@@ -1,0 +1,114 @@
+package stats_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExampleWinsorize() {
+	w, _ := stats.Winsorize([]float64{1, 2, 3, 4, 100}, 0.2)
+	fmt.Println(w)
+	// Output: [2 2 3 4 4]
+}
+
+func TestWinsorize(t *testing.T) {
+	for _, c := range []struct {
+		in      []float64
+		percent float64
+		out     []float64
+	}{
+		{[]float64{1, 2, 3, 4, 100}, 0.2, []float64{2, 2, 3, 4, 4}},
+		// Verified against scipy.stats.mstats.winsorize and preserves
+		// the original element order
+		{
+			[]float64{4.2, 1.1, 9.9, 3.3, 2.7, 8.8, 5.5, 7.4, 6.6, 100.5},
+			0.2,
+			[]float64{4.2, 3.3, 8.8, 3.3, 3.3, 8.8, 5.5, 7.4, 6.6, 8.8},
+		},
+		{[]float64{1, 2, 3, 4, 5}, 0.1, []float64{1, 2, 3, 4, 5}},
+		{[]float64{42}, 0.4, []float64{42}},
+	} {
+		got, err := stats.Winsorize(c.in, c.percent)
+		if err != nil {
+			t.Errorf("Winsorize(%v, %v) returned an error: %v", c.in, c.percent, err)
+			continue
+		}
+		for i := range c.out {
+			if got[i] != c.out[i] {
+				t.Errorf("Winsorize(%v, %v) => %v != %v", c.in, c.percent, got, c.out)
+				break
+			}
+		}
+	}
+}
+
+func TestWinsorizeZeroPercentReturnsCopy(t *testing.T) {
+	data := []float64{3, 1, 2}
+	w, err := stats.Winsorize(data, 0)
+	if err != nil {
+		t.Errorf("Should not have returned an error: %v", err)
+	}
+	for i := range data {
+		if w[i] != data[i] {
+			t.Errorf("Winsorize(%v, 0) => %v != %v", data, w, data)
+			break
+		}
+	}
+	w[0] = 99
+	if data[0] != 3 {
+		t.Errorf("Output should be a copy but input was mutated: %v", data)
+	}
+}
+
+func TestWinsorizeInvalidInput(t *testing.T) {
+	w, err := stats.Winsorize([]float64{}, 0.1)
+	if err != stats.ErrEmptyInput {
+		t.Errorf("Expected ErrEmptyInput, got %v", err)
+	}
+	if w != nil {
+		t.Errorf("Expected nil output, got %v", w)
+	}
+
+	for _, percent := range []float64{-0.1, 0.5, 1.0, math.NaN()} {
+		w, err = stats.Winsorize([]float64{1, 2, 3}, percent)
+		if err != stats.ErrBounds {
+			t.Errorf("Winsorize percent %v expected ErrBounds, got %v", percent, err)
+		}
+		if w != nil {
+			t.Errorf("Winsorize percent %v expected nil output, got %v", percent, w)
+		}
+	}
+}
+
+func TestWinsorizeDoesNotMutateInput(t *testing.T) {
+	data := []float64{100, 1, 4, 2, 3}
+	_, err := stats.Winsorize(data, 0.2)
+	if err != nil {
+		t.Errorf("Should not have returned an error: %v", err)
+	}
+	want := []float64{100, 1, 4, 2, 3}
+	for i := range want {
+		if data[i] != want[i] {
+			t.Errorf("Input was mutated: %v != %v", data, want)
+			break
+		}
+	}
+}
+
+func TestFloat64DataWinsorize(t *testing.T) {
+	data := stats.Float64Data{1, 2, 3, 4, 100}
+	w, err := data.Winsorize(0.2)
+	if err != nil {
+		t.Errorf("Should not have returned an error: %v", err)
+	}
+	want := []float64{2, 2, 3, 4, 4}
+	for i := range want {
+		if w[i] != want[i] {
+			t.Errorf("Winsorize(0.2) => %v != %v", w, want)
+			break
+		}
+	}
+}


### PR DESCRIPTION
Adds two robust statistics matching scipy `trim_mean` and `scipy.stats.mstats.winsorize`:

- `TrimmedMean(input, percent)` — sorts a copy, drops floor(n·percent) elements from each tail, means the rest; percent 0 equals `Mean`
- `Winsorize(input, percent)` — clamps values beyond the k-th smallest/largest to those values, preserving original element order; percent 0 returns a copy

`percent` is the fraction per tail, valid range [0, 0.5) (`ErrBounds` outside it, including NaN); empty input returns `ErrEmptyInput`. Method wrappers for both. Inputs never mutated.

## Test plan

- [x] `TrimmedMean([1,2,3,4,100], 0.2)` = 3; percent 0 equals Mean; scipy reference value verified
- [x] `Winsorize([1,2,3,4,100], 0.2)` = [2 2 3 4 4] in original order; scipy reference verified
- [x] percent < 0, ≥ 0.5, NaN → ErrBounds; empty → ErrEmptyInput
- [x] Input-mutation assertions for both
- [x] `go test ./...` passes, package coverage 100.0%, gofmt clean