### PR TITLE
feat: add MovingMedian, MovingMin, MovingMax, MovingSum, and EWMA

### DIFF
--- a/ewma.go
+++ b/ewma.go
@@ -1,0 +1,32 @@
+package stats
+
+// EWMA calculates the exponentially weighted moving average of the input
+// with smoothing factor alpha. The first output equals the first input and
+// each subsequent entry is alpha*input[i] + (1-alpha)*output[i-1], so the
+// result has the same length as the input. The alpha must satisfy
+// 0 < alpha <= 1 or ErrBounds is returned. An empty input returns
+// ErrEmptyInput.
+func EWMA(input Float64Data, alpha float64) ([]float64, error) {
+
+	if input.Len() == 0 {
+		return nil, ErrEmptyInput
+	}
+
+	if alpha <= 0 || alpha > 1 {
+		return nil, ErrBounds
+	}
+
+	output := make([]float64, input.Len())
+
+	output[0] = input[0]
+	for i := 1; i < input.Len(); i++ {
+		output[i] = alpha*input[i] + (1-alpha)*output[i-1]
+	}
+
+	return output, nil
+}
+
+// EWMA returns the exponentially weighted moving average of the data with smoothing factor alpha
+func (f Float64Data) EWMA(alpha float64) ([]float64, error) {
+	return EWMA(f, alpha)
+}

--- a/ewma_test.go
+++ b/ewma_test.go
@@ -1,0 +1,84 @@
+package stats_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExampleEWMA() {
+	data := []float64{1, 2, 3}
+	ewma, _ := stats.EWMA(data, 0.5)
+	fmt.Println(ewma)
+	// Output: [1 1.5 2.25]
+}
+
+func TestEWMA(t *testing.T) {
+	for _, c := range []struct {
+		in    []float64
+		alpha float64
+		out   []float64
+	}{
+		{[]float64{1, 2, 3}, 0.5, []float64{1, 1.5, 2.25}},
+		{[]float64{4}, 0.25, []float64{4}},
+		{[]float64{2, 2, 2}, 0.75, []float64{2, 2, 2}},
+	} {
+		got, err := stats.EWMA(c.in, c.alpha)
+		if err != nil {
+			t.Errorf("EWMA(%v, %v) returned an error", c.in, c.alpha)
+		}
+		if !reflect.DeepEqual(c.out, got) {
+			t.Errorf("EWMA(%v, %v) => %v != %v", c.in, c.alpha, got, c.out)
+		}
+	}
+}
+
+func TestEWMAAlphaOneCopiesInput(t *testing.T) {
+	in := []float64{5, 6, 7}
+	got, err := stats.EWMA(in, 1)
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if !reflect.DeepEqual(in, got) {
+		t.Errorf("EWMA(%v, 1) => %v != input", in, got)
+	}
+	got[0] = 99
+	if in[0] != 5 {
+		t.Errorf("EWMA(_, 1) must return a copy, not the input slice")
+	}
+}
+
+func TestEWMAInvalidInput(t *testing.T) {
+	_, err := stats.EWMA([]float64{}, 0.5)
+	if err != stats.ErrEmptyInput {
+		t.Errorf("Empty input should have returned ErrEmptyInput, got %v", err)
+	}
+	for _, alpha := range []float64{0, -0.5, 1.5} {
+		_, err := stats.EWMA([]float64{1, 2, 3}, alpha)
+		if err != stats.ErrBounds {
+			t.Errorf("Alpha %v should have returned ErrBounds, got %v", alpha, err)
+		}
+	}
+}
+
+func TestEWMADoesNotMutateInput(t *testing.T) {
+	in := []float64{1, 2, 3}
+	want := []float64{1, 2, 3}
+	_, _ = stats.EWMA(in, 0.5)
+	if !reflect.DeepEqual(want, in) {
+		t.Errorf("Input slice was mutated: %v != %v", in, want)
+	}
+}
+
+func TestFloat64DataEWMA(t *testing.T) {
+	data := stats.Float64Data{1, 2, 3}
+	got, err := data.EWMA(0.5)
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if !reflect.DeepEqual([]float64{1, 1.5, 2.25}, got) {
+		t.Errorf("Float64Data.EWMA(0.5) => %v != [1 1.5 2.25]", got)
+	}
+}

--- a/moving.go
+++ b/moving.go
@@ -1,0 +1,125 @@
+package stats
+
+// MovingMedian calculates the rolling median of the input over a trailing
+// window. Only fully-populated windows produce output, so the result has
+// len(input)-window+1 entries and entry i is the median of input[i : i+window].
+// The window must satisfy 1 <= window <= len(input) or ErrBounds is
+// returned. An empty input returns ErrEmptyInput.
+func MovingMedian(input Float64Data, window int) ([]float64, error) {
+
+	if input.Len() == 0 {
+		return nil, ErrEmptyInput
+	}
+
+	if window < 1 || window > input.Len() {
+		return nil, ErrBounds
+	}
+
+	output := make([]float64, input.Len()-window+1)
+
+	for i := range output {
+		// Median cannot fail here since every window is non-empty
+		median, _ := Median(input[i : i+window])
+		output[i] = median
+	}
+
+	return output, nil
+}
+
+// MovingMin calculates the rolling minimum of the input over a trailing
+// window. Only fully-populated windows produce output, so the result has
+// len(input)-window+1 entries and entry i is the minimum of
+// input[i : i+window]. The window must satisfy 1 <= window <= len(input) or
+// ErrBounds is returned. An empty input returns ErrEmptyInput.
+func MovingMin(input Float64Data, window int) ([]float64, error) {
+
+	if input.Len() == 0 {
+		return nil, ErrEmptyInput
+	}
+
+	if window < 1 || window > input.Len() {
+		return nil, ErrBounds
+	}
+
+	output := make([]float64, input.Len()-window+1)
+
+	for i := range output {
+		// Min cannot fail here since every window is non-empty
+		min, _ := Min(input[i : i+window])
+		output[i] = min
+	}
+
+	return output, nil
+}
+
+// MovingMax calculates the rolling maximum of the input over a trailing
+// window. Only fully-populated windows produce output, so the result has
+// len(input)-window+1 entries and entry i is the maximum of
+// input[i : i+window]. The window must satisfy 1 <= window <= len(input) or
+// ErrBounds is returned. An empty input returns ErrEmptyInput.
+func MovingMax(input Float64Data, window int) ([]float64, error) {
+
+	if input.Len() == 0 {
+		return nil, ErrEmptyInput
+	}
+
+	if window < 1 || window > input.Len() {
+		return nil, ErrBounds
+	}
+
+	output := make([]float64, input.Len()-window+1)
+
+	for i := range output {
+		// Max cannot fail here since every window is non-empty
+		max, _ := Max(input[i : i+window])
+		output[i] = max
+	}
+
+	return output, nil
+}
+
+// MovingSum calculates the rolling sum of the input over a trailing
+// window. Only fully-populated windows produce output, so the result has
+// len(input)-window+1 entries and entry i is the sum of input[i : i+window].
+// The window must satisfy 1 <= window <= len(input) or ErrBounds is
+// returned. An empty input returns ErrEmptyInput.
+func MovingSum(input Float64Data, window int) ([]float64, error) {
+
+	if input.Len() == 0 {
+		return nil, ErrEmptyInput
+	}
+
+	if window < 1 || window > input.Len() {
+		return nil, ErrBounds
+	}
+
+	output := make([]float64, input.Len()-window+1)
+
+	for i := range output {
+		// Sum cannot fail here since every window is non-empty
+		sum, _ := Sum(input[i : i+window])
+		output[i] = sum
+	}
+
+	return output, nil
+}
+
+// MovingMedian returns the rolling median of the data over a trailing window
+func (f Float64Data) MovingMedian(window int) ([]float64, error) {
+	return MovingMedian(f, window)
+}
+
+// MovingMin returns the rolling minimum of the data over a trailing window
+func (f Float64Data) MovingMin(window int) ([]float64, error) {
+	return MovingMin(f, window)
+}
+
+// MovingMax returns the rolling maximum of the data over a trailing window
+func (f Float64Data) MovingMax(window int) ([]float64, error) {
+	return MovingMax(f, window)
+}
+
+// MovingSum returns the rolling sum of the data over a trailing window
+func (f Float64Data) MovingSum(window int) ([]float64, error) {
+	return MovingSum(f, window)
+}

--- a/moving_test.go
+++ b/moving_test.go
@@ -1,0 +1,247 @@
+package stats_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExampleMovingMedian() {
+	data := []float64{5, 1, 4, 2, 3}
+	median, _ := stats.MovingMedian(data, 3)
+	fmt.Println(median)
+	// Output: [4 2 3]
+}
+
+func ExampleMovingMin() {
+	data := []float64{5, 1, 4, 2, 3}
+	min, _ := stats.MovingMin(data, 3)
+	fmt.Println(min)
+	// Output: [1 1 2]
+}
+
+func ExampleMovingMax() {
+	data := []float64{5, 1, 4, 2, 3}
+	max, _ := stats.MovingMax(data, 3)
+	fmt.Println(max)
+	// Output: [5 4 4]
+}
+
+func ExampleMovingSum() {
+	data := []float64{1, 2, 3, 4, 5}
+	sum, _ := stats.MovingSum(data, 3)
+	fmt.Println(sum)
+	// Output: [6 9 12]
+}
+
+func TestMovingMedian(t *testing.T) {
+	for _, c := range []struct {
+		in     []float64
+		window int
+		out    []float64
+	}{
+		{[]float64{5, 1, 4, 2, 3}, 3, []float64{4, 2, 3}},
+		{[]float64{5, 1, 4, 2, 3}, 1, []float64{5, 1, 4, 2, 3}},
+		{[]float64{1, 4, 9, 16}, 2, []float64{2.5, 6.5, 12.5}},
+	} {
+		got, err := stats.MovingMedian(c.in, c.window)
+		if err != nil {
+			t.Errorf("MovingMedian(%v, %d) returned an error", c.in, c.window)
+		}
+		if !reflect.DeepEqual(c.out, got) {
+			t.Errorf("MovingMedian(%v, %d) => %v != %v", c.in, c.window, got, c.out)
+		}
+	}
+}
+
+func TestMovingMin(t *testing.T) {
+	for _, c := range []struct {
+		in     []float64
+		window int
+		out    []float64
+	}{
+		{[]float64{5, 1, 4, 2, 3}, 3, []float64{1, 1, 2}},
+		{[]float64{5, 1, 4, 2, 3}, 1, []float64{5, 1, 4, 2, 3}},
+		{[]float64{3, 2, 5, 1}, 2, []float64{2, 2, 1}},
+	} {
+		got, err := stats.MovingMin(c.in, c.window)
+		if err != nil {
+			t.Errorf("MovingMin(%v, %d) returned an error", c.in, c.window)
+		}
+		if !reflect.DeepEqual(c.out, got) {
+			t.Errorf("MovingMin(%v, %d) => %v != %v", c.in, c.window, got, c.out)
+		}
+	}
+}
+
+func TestMovingMax(t *testing.T) {
+	for _, c := range []struct {
+		in     []float64
+		window int
+		out    []float64
+	}{
+		{[]float64{5, 1, 4, 2, 3}, 3, []float64{5, 4, 4}},
+		{[]float64{5, 1, 4, 2, 3}, 1, []float64{5, 1, 4, 2, 3}},
+		{[]float64{3, 2, 5, 1}, 2, []float64{3, 5, 5}},
+	} {
+		got, err := stats.MovingMax(c.in, c.window)
+		if err != nil {
+			t.Errorf("MovingMax(%v, %d) returned an error", c.in, c.window)
+		}
+		if !reflect.DeepEqual(c.out, got) {
+			t.Errorf("MovingMax(%v, %d) => %v != %v", c.in, c.window, got, c.out)
+		}
+	}
+}
+
+func TestMovingSum(t *testing.T) {
+	for _, c := range []struct {
+		in     []float64
+		window int
+		out    []float64
+	}{
+		{[]float64{1, 2, 3, 4, 5}, 3, []float64{6, 9, 12}},
+		{[]float64{1, 2, 3, 4, 5}, 1, []float64{1, 2, 3, 4, 5}},
+		{[]float64{1, 4, 9}, 2, []float64{5, 13}},
+	} {
+		got, err := stats.MovingSum(c.in, c.window)
+		if err != nil {
+			t.Errorf("MovingSum(%v, %d) returned an error", c.in, c.window)
+		}
+		if !reflect.DeepEqual(c.out, got) {
+			t.Errorf("MovingSum(%v, %d) => %v != %v", c.in, c.window, got, c.out)
+		}
+	}
+}
+
+func TestMovingFullWindowEqualsScalar(t *testing.T) {
+	in := []float64{2.2, 4.4, 1.1, 3.3}
+	for _, c := range []struct {
+		name   string
+		moving func(stats.Float64Data, int) ([]float64, error)
+		scalar func(stats.Float64Data) (float64, error)
+	}{
+		{"MovingMedian", stats.MovingMedian, stats.Median},
+		{"MovingMin", stats.MovingMin, stats.Min},
+		{"MovingMax", stats.MovingMax, stats.Max},
+		{"MovingSum", stats.MovingSum, stats.Sum},
+	} {
+		got, err := c.moving(in, len(in))
+		if err != nil {
+			t.Errorf("%s returned an error", c.name)
+		}
+		if len(got) != 1 {
+			t.Fatalf("%s expected a single element, got %d", c.name, len(got))
+		}
+		want, _ := c.scalar(in)
+		if got[0] != want {
+			t.Errorf("%s full window %v != scalar %v", c.name, got[0], want)
+		}
+	}
+}
+
+func TestMovingWindowOneCopiesInput(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		moving func(stats.Float64Data, int) ([]float64, error)
+	}{
+		{"MovingMedian", stats.MovingMedian},
+		{"MovingMin", stats.MovingMin},
+		{"MovingMax", stats.MovingMax},
+		{"MovingSum", stats.MovingSum},
+	} {
+		in := []float64{5, 6, 7}
+		got, err := c.moving(in, 1)
+		if err != nil {
+			t.Errorf("%s returned an error", c.name)
+		}
+		if !reflect.DeepEqual(in, got) {
+			t.Errorf("%s(%v, 1) => %v != input", c.name, in, got)
+		}
+		got[0] = 99
+		if in[0] != 5 {
+			t.Errorf("%s(_, 1) must return a copy, not the input slice", c.name)
+		}
+	}
+}
+
+func TestMovingInvalidInput(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		moving func(stats.Float64Data, int) ([]float64, error)
+	}{
+		{"MovingMedian", stats.MovingMedian},
+		{"MovingMin", stats.MovingMin},
+		{"MovingMax", stats.MovingMax},
+		{"MovingSum", stats.MovingSum},
+	} {
+		_, err := c.moving([]float64{}, 1)
+		if err != stats.ErrEmptyInput {
+			t.Errorf("%s empty input should have returned ErrEmptyInput, got %v", c.name, err)
+		}
+		for _, window := range []int{0, -1, 4} {
+			_, err := c.moving([]float64{1, 2, 3}, window)
+			if err != stats.ErrBounds {
+				t.Errorf("%s window %d should have returned ErrBounds, got %v", c.name, window, err)
+			}
+		}
+	}
+}
+
+func TestMovingDoesNotMutateInput(t *testing.T) {
+	in := []float64{5, 1, 4, 2, 3}
+	want := []float64{5, 1, 4, 2, 3}
+	_, _ = stats.MovingMedian(in, 3)
+	_, _ = stats.MovingMin(in, 3)
+	_, _ = stats.MovingMax(in, 3)
+	_, _ = stats.MovingSum(in, 3)
+	if !reflect.DeepEqual(want, in) {
+		t.Errorf("Input slice was mutated: %v != %v", in, want)
+	}
+}
+
+func TestFloat64DataMovingMedian(t *testing.T) {
+	data := stats.Float64Data{5, 1, 4, 2, 3}
+	got, err := data.MovingMedian(3)
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if !reflect.DeepEqual([]float64{4, 2, 3}, got) {
+		t.Errorf("Float64Data.MovingMedian(3) => %v != [4 2 3]", got)
+	}
+}
+
+func TestFloat64DataMovingMin(t *testing.T) {
+	data := stats.Float64Data{5, 1, 4, 2, 3}
+	got, err := data.MovingMin(3)
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if !reflect.DeepEqual([]float64{1, 1, 2}, got) {
+		t.Errorf("Float64Data.MovingMin(3) => %v != [1 1 2]", got)
+	}
+}
+
+func TestFloat64DataMovingMax(t *testing.T) {
+	data := stats.Float64Data{5, 1, 4, 2, 3}
+	got, err := data.MovingMax(3)
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if !reflect.DeepEqual([]float64{5, 4, 4}, got) {
+		t.Errorf("Float64Data.MovingMax(3) => %v != [5 4 4]", got)
+	}
+}
+
+func TestFloat64DataMovingSum(t *testing.T) {
+	data := stats.Float64Data{1, 2, 3, 4, 5}
+	got, err := data.MovingSum(3)
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if !reflect.DeepEqual([]float64{6, 9, 12}, got) {
+		t.Errorf("Float64Data.MovingSum(3) => %v != [6 9 12]", got)
+	}
+}


### PR DESCRIPTION
Completes the rolling family started by MovingAverage/MovingStdDev (MATLAB movmedian/movmin/movmax/movsum, pandas rolling + ewm):

- `MovingMedian` / `MovingMin` / `MovingMax` / `MovingSum` — trailing window, valid-only output of length `len(input) − window + 1`, mirroring rolling.go exactly; `ErrBounds` unless 1 ≤ window ≤ len(input)
- `EWMA(input, alpha)` — pandas `ewm(alpha=α, adjust=False).mean()` semantics: out[0] = input[0], out[i] = α·x[i] + (1−α)·out[i−1]; `ErrBounds` unless 0 < alpha ≤ 1

Method wrappers for all five. Inputs never mutated; rolling.go untouched.

## Test plan

- [x] `MovingSum([1,2,3,4,5], 3)` = [6 9 12]; `MovingMedian([5,1,4,2,3], 3)` = [4 2 3]; Min/Max spot-checked
- [x] window == len equals the scalar function; window == 1 returns a copy
- [x] `EWMA([1,2,3], 0.5)` = [1 1.5 2.25]; alpha 1 returns a copy; alpha 0/negative/>1 → ErrBounds
- [x] Empty-input and window-bounds errors tested for all five; mutation assertions
- [x] `go test ./...` passes, package coverage 100.0%, gofmt clean