### PR TITLE
feat: add SEM, RMS, Product, and PercentileOfScore

### DIFF
--- a/percentile_of_score.go
+++ b/percentile_of_score.go
@@ -1,0 +1,31 @@
+package stats
+
+import "math"
+
+// PercentileOfScore calculates the percentile rank of a score
+// relative to a slice of floats, defined as the percentage of
+// values strictly below the score plus half the percentage of
+// values equal to the score. The result is between 0 and 100.
+// This matches the behavior of Python's
+// scipy.stats.percentileofscore with kind="rank".
+func PercentileOfScore(input Float64Data, score float64) (float64, error) {
+	if input.Len() == 0 {
+		return math.NaN(), ErrEmptyInput
+	}
+
+	var below, equal float64
+	for _, v := range input {
+		if v < score {
+			below++
+		} else if v == score {
+			equal++
+		}
+	}
+
+	return 100 * (below + 0.5*equal) / float64(input.Len()), nil
+}
+
+// PercentileOfScore calculates the percentile rank of a score relative to the data
+func (f Float64Data) PercentileOfScore(score float64) (float64, error) {
+	return PercentileOfScore(f, score)
+}

--- a/percentile_of_score_test.go
+++ b/percentile_of_score_test.go
@@ -1,0 +1,62 @@
+package stats_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExamplePercentileOfScore() {
+	rank, _ := stats.PercentileOfScore([]float64{1, 2, 3, 4}, 3)
+	fmt.Println(rank)
+	// Output: 62.5
+}
+
+func TestPercentileOfScore(t *testing.T) {
+	for _, c := range []struct {
+		in    []float64
+		score float64
+		out   float64
+	}{
+		{[]float64{1, 2, 3, 4}, 3, 62.5},
+		{[]float64{1, 2, 3, 4}, 0, 0},
+		{[]float64{1, 2, 3, 4}, 5, 100},
+		{[]float64{1, 2, 3, 4}, 2.5, 50},
+		{[]float64{1, 2, 2, 2, 3}, 2, 50},
+		{[]float64{2, 2, 2}, 2, 50},
+		{[]float64{1, 2, 3, 4}, 1, 12.5},
+		{[]float64{1, 2, 3, 4}, 4, 87.5},
+	} {
+		got, err := stats.PercentileOfScore(c.in, c.score)
+		if err != nil {
+			t.Errorf("Returned an error")
+		}
+		if math.Abs(got-c.out) > 0.0000001 {
+			t.Errorf("PercentileOfScore(%v, %v) => %v != %v", c.in, c.score, got, c.out)
+		}
+	}
+}
+
+func TestPercentileOfScoreEmptyInput(t *testing.T) {
+	r, err := stats.PercentileOfScore([]float64{}, 1)
+	if err != stats.ErrEmptyInput {
+		t.Errorf("expected ErrEmptyInput, got %v", err)
+	}
+	if !math.IsNaN(r) {
+		t.Errorf("expected NaN, got %v", r)
+	}
+}
+
+func TestFloat64DataPercentileOfScore(t *testing.T) {
+	data := stats.Float64Data{1, 2, 3, 4}
+
+	r, err := data.PercentileOfScore(3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r != 62.5 {
+		t.Errorf("got %v, want 62.5", r)
+	}
+}

--- a/product.go
+++ b/product.go
@@ -1,0 +1,26 @@
+package stats
+
+import "math"
+
+// Product calculates the product of a slice of floats by
+// multiplying the values from left to right. It is the scalar
+// counterpart of CumulativeProduct. Large inputs can overflow
+// to Inf; use GeometricMean for an overflow-safe summary of
+// multiplicative data.
+func Product(input Float64Data) (float64, error) {
+	if input.Len() == 0 {
+		return math.NaN(), ErrEmptyInput
+	}
+
+	product := 1.0
+	for _, v := range input {
+		product *= v
+	}
+
+	return product, nil
+}
+
+// Product calculates the product of the data
+func (f Float64Data) Product() (float64, error) {
+	return Product(f)
+}

--- a/product_test.go
+++ b/product_test.go
@@ -1,0 +1,58 @@
+package stats_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExampleProduct() {
+	product, _ := stats.Product([]float64{2, 3, 4})
+	fmt.Println(product)
+	// Output: 24
+}
+
+func TestProduct(t *testing.T) {
+	for _, c := range []struct {
+		in  []float64
+		out float64
+	}{
+		{[]float64{2, 3, 4}, 24},
+		{[]float64{2, 0.5, 4}, 4},
+		{[]float64{-1, 2, -3}, 6},
+		{[]float64{5, 0, 3}, 0},
+		{[]float64{7}, 7},
+	} {
+		got, err := stats.Product(c.in)
+		if err != nil {
+			t.Errorf("Returned an error")
+		}
+		if math.Abs(got-c.out) > 0.0000001 {
+			t.Errorf("Product(%v) => %v != %v", c.in, got, c.out)
+		}
+	}
+}
+
+func TestProductEmptyInput(t *testing.T) {
+	r, err := stats.Product([]float64{})
+	if err != stats.ErrEmptyInput {
+		t.Errorf("expected ErrEmptyInput, got %v", err)
+	}
+	if !math.IsNaN(r) {
+		t.Errorf("expected NaN, got %v", r)
+	}
+}
+
+func TestFloat64DataProduct(t *testing.T) {
+	data := stats.Float64Data{2, 3, 4}
+
+	r, err := data.Product()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r != 24 {
+		t.Errorf("got %v, want 24", r)
+	}
+}

--- a/rms.go
+++ b/rms.go
@@ -1,0 +1,23 @@
+package stats
+
+import "math"
+
+// RMS calculates the root mean square of a slice of floats,
+// defined as the square root of the mean of the squared values.
+func RMS(input Float64Data) (float64, error) {
+	if input.Len() == 0 {
+		return math.NaN(), ErrEmptyInput
+	}
+
+	var sumSquares float64
+	for _, v := range input {
+		sumSquares += v * v
+	}
+
+	return math.Sqrt(sumSquares / float64(input.Len())), nil
+}
+
+// RMS calculates the root mean square of the data
+func (f Float64Data) RMS() (float64, error) {
+	return RMS(f)
+}

--- a/rms_test.go
+++ b/rms_test.go
@@ -1,0 +1,58 @@
+package stats_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExampleRMS() {
+	rms, _ := stats.RMS([]float64{3, 4})
+	fmt.Printf("%.4f", rms)
+	// Output: 3.5355
+}
+
+func TestRMS(t *testing.T) {
+	for _, c := range []struct {
+		in  []float64
+		out float64
+	}{
+		{[]float64{3, 4}, 3.5355339059327378},
+		{[]float64{1, 1, 1}, 1},
+		{[]float64{-3, 4}, 3.5355339059327378},
+		{[]float64{0, 0, 0}, 0},
+		{[]float64{2}, 2},
+	} {
+		got, err := stats.RMS(c.in)
+		if err != nil {
+			t.Errorf("Returned an error")
+		}
+		if math.Abs(got-c.out) > 0.0000001 {
+			t.Errorf("RMS(%v) => %v != %v", c.in, got, c.out)
+		}
+	}
+}
+
+func TestRMSEmptyInput(t *testing.T) {
+	r, err := stats.RMS([]float64{})
+	if err != stats.ErrEmptyInput {
+		t.Errorf("expected ErrEmptyInput, got %v", err)
+	}
+	if !math.IsNaN(r) {
+		t.Errorf("expected NaN, got %v", r)
+	}
+}
+
+func TestFloat64DataRMS(t *testing.T) {
+	data := stats.Float64Data{3, 4}
+
+	r, err := data.RMS()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if math.Abs(r-3.5355339059327378) > 0.0000001 {
+		t.Errorf("got %v, want ~3.5355", r)
+	}
+}

--- a/sem.go
+++ b/sem.go
@@ -1,0 +1,24 @@
+package stats
+
+import "math"
+
+// SEM calculates the standard error of the mean of a slice
+// of floats, defined as the sample standard deviation divided
+// by the square root of the sample size. This matches the
+// behavior of Python's scipy.stats.sem with ddof=1.
+func SEM(input Float64Data) (float64, error) {
+	if input.Len() == 0 {
+		return math.NaN(), ErrEmptyInput
+	}
+
+	// Input is known to be non-empty so the sample standard
+	// deviation cannot return an error
+	sd, _ := StandardDeviationSample(input)
+
+	return sd / math.Sqrt(float64(input.Len())), nil
+}
+
+// SEM calculates the standard error of the mean of the data
+func (f Float64Data) SEM() (float64, error) {
+	return SEM(f)
+}

--- a/sem_test.go
+++ b/sem_test.go
@@ -1,0 +1,56 @@
+package stats_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExampleSEM() {
+	sem, _ := stats.SEM([]float64{1, 2, 3, 4, 5})
+	fmt.Printf("%.4f", sem)
+	// Output: 0.7071
+}
+
+func TestSEM(t *testing.T) {
+	for _, c := range []struct {
+		in  []float64
+		out float64
+	}{
+		{[]float64{1, 2, 3, 4, 5}, 0.7071067811865476},
+		{[]float64{2, 4, 6}, 1.1547005383792515},
+		{[]float64{5, 5, 5, 5}, 0},
+	} {
+		got, err := stats.SEM(c.in)
+		if err != nil {
+			t.Errorf("Returned an error")
+		}
+		if math.Abs(got-c.out) > 0.0000001 {
+			t.Errorf("SEM(%v) => %v != %v", c.in, got, c.out)
+		}
+	}
+}
+
+func TestSEMEmptyInput(t *testing.T) {
+	r, err := stats.SEM([]float64{})
+	if err != stats.ErrEmptyInput {
+		t.Errorf("expected ErrEmptyInput, got %v", err)
+	}
+	if !math.IsNaN(r) {
+		t.Errorf("expected NaN, got %v", r)
+	}
+}
+
+func TestFloat64DataSEM(t *testing.T) {
+	data := stats.Float64Data{1, 2, 3, 4, 5}
+
+	r, err := data.SEM()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if math.Abs(r-0.7071067811865476) > 0.0000001 {
+		t.Errorf("got %v, want ~0.7071", r)
+	}
+}


### PR DESCRIPTION
Adds four small scalar summaries (scipy `sem`, MATLAB `rms`, numpy `prod`, scipy `percentileofscore`):

- `SEM` — standard error of the mean: sample standard deviation / √n
- `RMS` — √(mean(x²))
- `Product` — plain left-to-right multiplication; godoc points overflow-sensitive uses to GeometricMean
- `PercentileOfScore(input, score)` — scipy `kind="rank"`: 100·(below + 0.5·equal)/n, returns 0–100

Method wrappers for all four; one file per function. All return `math.NaN(), ErrEmptyInput` on empty.

## Test plan

- [x] `SEM([1,2,3,4,5])` ≈ 0.7071; `RMS([3,4])` ≈ 3.5355; `Product([2,3,4])` = 24
- [x] `PercentileOfScore([1,2,3,4], 3)` = 62.5; below-all → 0, above-all → 100, ties → 50
- [x] Empty → ErrEmptyInput for all four; method wrappers exercised
- [x] `go test ./...` passes, package coverage 100.0%, gofmt clean