### PR TITLE
feat: add Histogram with numpy-compatible equal-width bins

### DIFF
--- a/histogram.go
+++ b/histogram.go
@@ -1,0 +1,57 @@
+package stats
+
+import "sort"
+
+// Histogram calculates the histogram of a slice using the given
+// number of equal-width bins over [min, max], returning the count
+// of values in each bin along with the bins+1 bin edges. Each bin
+// is half-open [edges[i], edges[i+1]) except the last, which also
+// includes the maximum value.
+func Histogram(input Float64Data, bins int) ([]int, []float64, error) {
+
+	if input.Len() == 0 {
+		return nil, nil, ErrEmptyInput
+	}
+
+	if bins < 1 {
+		return nil, nil, ErrBounds
+	}
+
+	// Disregard errors, since input is not empty
+	min, _ := Min(input)
+	max, _ := Max(input)
+
+	// Expand the range by 0.5 on each side like
+	// numpy when all of the values are equal
+	if min == max {
+		min -= 0.5
+		max += 0.5
+	}
+
+	// Build bins+1 equal-width bin edges from min to max
+	width := (max - min) / float64(bins)
+	edges := make([]float64, bins+1)
+	for i := range edges {
+		edges[i] = min + width*float64(i)
+	}
+	edges[bins] = max
+
+	// Count each value into the last bin whose left
+	// edge does not exceed it, so the maximum value
+	// lands in the final closed bin
+	counts := make([]int, bins)
+	for _, v := range input {
+		i := sort.Search(len(edges), func(i int) bool { return edges[i] > v }) - 1
+		if i == bins {
+			i--
+		}
+		counts[i]++
+	}
+
+	return counts, edges, nil
+}
+
+// Histogram returns the counts and equal-width bin edges of the data
+func (f Float64Data) Histogram(bins int) ([]int, []float64, error) {
+	return Histogram(f, bins)
+}

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -1,0 +1,113 @@
+package stats_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExampleHistogram() {
+	counts, edges, _ := stats.Histogram([]float64{1, 2, 1, 3, 4}, 3)
+	fmt.Println(counts, edges)
+	// Output: [2 1 2] [1 2 3 4]
+}
+
+func TestHistogram(t *testing.T) {
+	for _, c := range []struct {
+		in     stats.Float64Data
+		bins   int
+		counts []int
+		edges  []float64
+	}{
+		{stats.Float64Data{1, 2, 1, 3, 4}, 3, []int{2, 1, 2}, []float64{1, 2, 3, 4}},
+		{stats.Float64Data{1, 1.5, 2, 2.5, 3}, 4, []int{1, 1, 1, 2}, []float64{1, 1.5, 2, 2.5, 3}},
+		{stats.Float64Data{5, 5, 5}, 4, []int{0, 0, 3, 0}, []float64{4.5, 4.75, 5, 5.25, 5.5}},
+		{stats.Float64Data{7}, 1, []int{1}, []float64{6.5, 7.5}},
+		{stats.Float64Data{0, 10}, 2, []int{1, 1}, []float64{0, 5, 10}},
+	} {
+		counts, edges, err := stats.Histogram(c.in, c.bins)
+		if err != nil {
+			t.Errorf("Returned an error")
+		}
+		if !reflect.DeepEqual(counts, c.counts) {
+			t.Errorf("Histogram(%v, %d) counts => %v != %v", c.in, c.bins, counts, c.counts)
+		}
+		if !reflect.DeepEqual(edges, c.edges) {
+			t.Errorf("Histogram(%v, %d) edges => %v != %v", c.in, c.bins, edges, c.edges)
+		}
+		total := 0
+		for _, count := range counts {
+			total += count
+		}
+		if total != c.in.Len() {
+			t.Errorf("Histogram(%v, %d) counts sum => %d != %d", c.in, c.bins, total, c.in.Len())
+		}
+	}
+}
+
+func TestHistogramMaxInLastBin(t *testing.T) {
+	counts, _, err := stats.Histogram([]float64{1, 2, 1, 3, 4}, 3)
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if counts[len(counts)-1] != 2 {
+		t.Errorf("Maximum value not counted in the last bin => %v", counts)
+	}
+}
+
+func TestHistogramEmptyInput(t *testing.T) {
+	_, _, err := stats.Histogram([]float64{}, 3)
+	if err != stats.ErrEmptyInput {
+		t.Errorf("Empty slice didn't return expected error; got %v", err)
+	}
+}
+
+func TestHistogramInvalidBins(t *testing.T) {
+	for _, bins := range []int{0, -1} {
+		_, _, err := stats.Histogram([]float64{1, 2, 3}, bins)
+		if err != stats.ErrBounds {
+			t.Errorf("Histogram with %d bins didn't return expected error; got %v", bins, err)
+		}
+	}
+}
+
+func TestHistogramDoesNotMutateInput(t *testing.T) {
+	in := stats.Float64Data{4, 1, 3, 2}
+	_, _, err := stats.Histogram(in, 2)
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if !reflect.DeepEqual(in, stats.Float64Data{4, 1, 3, 2}) {
+		t.Errorf("Input slice was mutated => %v", in)
+	}
+}
+
+func TestFloat64DataHistogram(t *testing.T) {
+	in := stats.Float64Data{1, 2, 1, 3, 4}
+	counts, edges, err := in.Histogram(3)
+	if err != nil {
+		t.Errorf("Returned an error")
+	}
+	if !reflect.DeepEqual(counts, []int{2, 1, 2}) {
+		t.Errorf("Histogram(3) counts => %v != %v", counts, []int{2, 1, 2})
+	}
+	if !reflect.DeepEqual(edges, []float64{1, 2, 3, 4}) {
+		t.Errorf("Histogram(3) edges => %v != %v", edges, []float64{1, 2, 3, 4})
+	}
+}
+
+func BenchmarkHistogramSmallFloatSlice(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _, _ = stats.Histogram(makeFloatSlice(5), 3)
+	}
+}
+
+func BenchmarkHistogramLargeFloatSlice(b *testing.B) {
+	lf := makeFloatSlice(100000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = stats.Histogram(lf, 10)
+	}
+}


### PR DESCRIPTION
Adds `Histogram(input, bins) (counts []int, edges []float64, err error)` with numpy `np.histogram` semantics: `bins` equal-width intervals over [min, max], bins+1 edges, every bin half-open [edge[i], edge[i+1]) except the last, which is closed so the max lands in the final bin. Constant input expands the range to [min − 0.5, min + 0.5] like numpy. `ErrEmptyInput` on empty; `ErrBounds` if bins < 1. Method wrapper included.

Note: the plan's acceptance example said `Histogram([1,2,1,3,4], 3)` → counts [3,1,1], but actual `np.histogram` returns [2,1,2] (edges [1,2,3,4]: the two 1s fall in bin 0, the 2 in bin 1, and 3 and 4 in bin 2). numpy fidelity was the stated goal, so the implementation and tests follow numpy.

## Test plan

- [x] `Histogram([1,2,1,3,4], 3)` = counts [2 1 2], edges [1 2 3 4] (numpy-verified)
- [x] Max lands in last bin (closed right edge tested explicitly); sum(counts) == len(input) asserted per case
- [x] Constant input matches numpy's ±0.5 expansion
- [x] bins 0/negative → ErrBounds; empty → ErrEmptyInput; input not mutated
- [x] `go test ./...` passes, package coverage 100.0%, gofmt clean