### PR TITLE
feat: add Interp for piecewise-linear interpolation

### DIFF
--- a/interp.go
+++ b/interp.go
@@ -1,0 +1,46 @@
+package stats
+
+import "sort"
+
+// Interp calculates the one-dimensional piecewise-linear interpolant to a
+// function with given discrete data points (xp, fp), evaluated at each x.
+// Values of x below xp[0] return fp[0] and values above xp[len(xp)-1] return
+// fp[len(xp)-1], so no extrapolation is performed. Unlike numpy's interp,
+// which silently returns nonsense for unsorted coordinates, xp must be
+// strictly increasing or ErrBounds is returned. An empty x or xp returns
+// ErrEmptyInput and xp and fp of different lengths return ErrSize.
+func Interp(x, xp, fp Float64Data) ([]float64, error) {
+
+	if x.Len() == 0 || xp.Len() == 0 {
+		return nil, ErrEmptyInput
+	}
+
+	if xp.Len() != fp.Len() {
+		return nil, ErrSize
+	}
+
+	for i := 1; i < xp.Len(); i++ {
+		if xp[i] <= xp[i-1] {
+			return nil, ErrBounds
+		}
+	}
+
+	output := make([]float64, x.Len())
+
+	for i, xv := range x {
+		switch {
+		case xv <= xp[0]:
+			output[i] = fp[0]
+		case xv >= xp[xp.Len()-1]:
+			output[i] = fp[fp.Len()-1]
+		default:
+			// The first index with xp[j] >= xv, which the clamping
+			// above guarantees is within [1, len(xp)-1]
+			j := sort.SearchFloat64s(xp, xv)
+			t := (xv - xp[j-1]) / (xp[j] - xp[j-1])
+			output[i] = fp[j-1] + t*(fp[j]-fp[j-1])
+		}
+	}
+
+	return output, nil
+}

--- a/interp_test.go
+++ b/interp_test.go
@@ -1,0 +1,59 @@
+package stats_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+func ExampleInterp() {
+	out, _ := stats.Interp([]float64{1.5}, []float64{1, 2}, []float64{10, 20})
+	fmt.Println(out)
+	// Output: [15]
+}
+
+func TestInterp(t *testing.T) {
+	for _, c := range []struct {
+		x   []float64
+		xp  []float64
+		fp  []float64
+		out []float64
+	}{
+		{[]float64{1.5}, []float64{1, 2}, []float64{10, 20}, []float64{15}},
+		{[]float64{0, 1, 1.5, 2.5, 4}, []float64{1, 2, 3}, []float64{10, 20, 40}, []float64{10, 10, 15, 30, 40}},
+		{[]float64{2.5, 4}, []float64{1, 2, 3, 5}, []float64{3, 2, 0, 4}, []float64{1, 2}},
+		{[]float64{-1, 0.5, 2}, []float64{1}, []float64{5}, []float64{5, 5, 5}},
+		{[]float64{-10}, []float64{0, 1}, []float64{2, 4}, []float64{2}},
+		{[]float64{10}, []float64{0, 1}, []float64{2, 4}, []float64{4}},
+	} {
+		got, err := stats.Interp(c.x, c.xp, c.fp)
+		if err != nil {
+			t.Errorf("Returned an error")
+		}
+		if !reflect.DeepEqual(c.out, got) {
+			t.Errorf("Interp(%.1f, %.1f, %.1f) => %.1f != %.1f", c.x, c.xp, c.fp, got, c.out)
+		}
+	}
+}
+
+func TestInterpInvalidInput(t *testing.T) {
+	for _, c := range []struct {
+		x   []float64
+		xp  []float64
+		fp  []float64
+		err error
+	}{
+		{[]float64{}, []float64{1, 2}, []float64{10, 20}, stats.ErrEmptyInput},
+		{[]float64{1.5}, []float64{}, []float64{}, stats.ErrEmptyInput},
+		{[]float64{1.5}, []float64{1, 2}, []float64{10}, stats.ErrSize},
+		{[]float64{1.5}, []float64{2, 1}, []float64{10, 20}, stats.ErrBounds},
+		{[]float64{1.5}, []float64{1, 1}, []float64{10, 20}, stats.ErrBounds},
+	} {
+		_, err := stats.Interp(c.x, c.xp, c.fp)
+		if err != c.err {
+			t.Errorf("Interp(%.1f, %.1f, %.1f) => %v != %v", c.x, c.xp, c.fp, err, c.err)
+		}
+	}
+}


### PR DESCRIPTION
Adds `Interp(x, xp, fp)` — numpy `np.interp` semantics: for each x[i], linearly interpolate between the surrounding (xp, fp) points; values outside the range clamp to fp[0] / fp[len−1] (no extrapolation). A single-point xp returns fp[0] for every x.

Validation is stricter than numpy (documented in the godoc): xp must be strictly increasing or `ErrBounds` is returned, rather than silently producing nonsense. `ErrSize` on len(xp) != len(fp); `ErrEmptyInput` on empty x or xp. No method wrapper — a three-slice signature doesn't fit the method style.

## Test plan

- [x] `Interp([1.5], [1,2], [10,20])` = [15]; multi-point cases match numpy references
- [x] Clamping tested both below and above the xp range
- [x] Single-point xp returns fp[0] for all x
- [x] Decreasing/duplicate xp → ErrBounds; length mismatch → ErrSize; empty x or xp → ErrEmptyInput
- [x] `go test ./...` passes, package coverage 100.0%, gofmt clean