### PR TITLE
Fix regression stability and invalid domains

### DIFF
--- a/regression.go
+++ b/regression.go
@@ -10,101 +10,130 @@ type Coordinate struct {
 	X, Y float64
 }
 
-// LinearRegression finds the least squares linear regression on data series
+// LinearRegression finds the least squares linear regression on data series.
+// A series without at least two distinct X values returns ErrBounds.
 func LinearRegression(s Series) (regressions Series, err error) {
 
 	if len(s) == 0 {
 		return nil, EmptyInputErr
 	}
 
-	// Placeholder for the math to be done
-	var sum [4]float64
-
-	// Loop over data keeping index in place
-	i := 0
-	for ; i < len(s); i++ {
-		sum[0] += s[i].X
-		sum[1] += s[i].Y
-		sum[2] += s[i].X * s[i].X
-		sum[3] += s[i].X * s[i].Y
+	var sumX, sumY float64
+	for _, coordinate := range s {
+		sumX += coordinate.X
+		sumY += coordinate.Y
 	}
+	meanX := sumX / float64(len(s))
+	meanY := sumY / float64(len(s))
 
-	// Find gradient and intercept
-	f := float64(i)
-	gradient := (f*sum[3] - sum[0]*sum[1]) / (f*sum[2] - sum[0]*sum[0])
-	intercept := (sum[1] / f) - (gradient * sum[0] / f)
+	var covariance, variance float64
+	for _, coordinate := range s {
+		dx := coordinate.X - meanX
+		covariance += dx * (coordinate.Y - meanY)
+		variance += dx * dx
+	}
+	if variance == 0 {
+		return nil, ErrBounds
+	}
+	gradient := covariance / variance
 
 	// Create the new regression series
 	for j := 0; j < len(s); j++ {
 		regressions = append(regressions, Coordinate{
 			X: s[j].X,
-			Y: s[j].X*gradient + intercept,
+			Y: meanY + gradient*(s[j].X-meanX),
 		})
 	}
 
 	return regressions, nil
 }
 
-// ExponentialRegression returns an exponential regression on data series
+// ExponentialRegression returns an exponential regression on data series.
+// A non-positive Y value returns ErrYCoord, and a series without at least two
+// distinct X values returns ErrBounds.
 func ExponentialRegression(s Series) (regressions Series, err error) {
 
 	if len(s) == 0 {
 		return nil, EmptyInputErr
 	}
 
-	var sum [6]float64
+	var sumY, sumDeltaXY, sumYLogY float64
+	referenceX := s[0].X
 
 	for i := 0; i < len(s); i++ {
-		if s[i].Y < 0 {
-			return nil, YCoordErr
+		if s[i].Y <= 0 {
+			return nil, ErrYCoord
 		}
-		sum[0] += s[i].X
-		sum[1] += s[i].Y
-		sum[2] += s[i].X * s[i].X * s[i].Y
-		sum[3] += s[i].Y * math.Log(s[i].Y)
-		sum[4] += s[i].X * s[i].Y * math.Log(s[i].Y)
-		sum[5] += s[i].X * s[i].Y
+		sumY += s[i].Y
+		sumDeltaXY += (s[i].X - referenceX) * s[i].Y
+		sumYLogY += s[i].Y * math.Log(s[i].Y)
 	}
+	meanDeltaX := sumDeltaXY / sumY
+	meanLogY := sumYLogY / sumY
 
-	denominator := (sum[1]*sum[2] - sum[5]*sum[5])
-	a := math.Pow(math.E, (sum[2]*sum[3]-sum[5]*sum[4])/denominator)
-	b := (sum[1]*sum[4] - sum[5]*sum[3]) / denominator
+	var covariance, variance float64
+	for _, coordinate := range s {
+		dx := coordinate.X - referenceX - meanDeltaX
+		covariance += coordinate.Y * dx * (math.Log(coordinate.Y) - meanLogY)
+		variance += coordinate.Y * dx * dx
+	}
+	if variance == 0 {
+		return nil, ErrBounds
+	}
+	b := covariance / variance
 
 	for j := 0; j < len(s); j++ {
 		regressions = append(regressions, Coordinate{
 			X: s[j].X,
-			Y: a * math.Exp(b*s[j].X),
+			Y: math.Exp(meanLogY + b*(s[j].X-referenceX-meanDeltaX)),
 		})
 	}
 
 	return regressions, nil
 }
 
-// LogarithmicRegression returns an logarithmic regression on data series
+// LogarithmicRegression returns a logarithmic regression on data series.
+// A non-positive X value or a series without at least two distinct X values
+// returns ErrBounds.
 func LogarithmicRegression(s Series) (regressions Series, err error) {
 
 	if len(s) == 0 {
 		return nil, EmptyInputErr
 	}
-
-	var sum [4]float64
-
-	i := 0
-	for ; i < len(s); i++ {
-		sum[0] += math.Log(s[i].X)
-		sum[1] += s[i].Y * math.Log(s[i].X)
-		sum[2] += s[i].Y
-		sum[3] += math.Pow(math.Log(s[i].X), 2)
+	if s[0].X <= 0 {
+		return nil, ErrBounds
 	}
 
-	f := float64(i)
-	a := (f*sum[1] - sum[2]*sum[0]) / (f*sum[3] - sum[0]*sum[0])
-	b := (sum[2] - a*sum[0]) / f
+	logX := make([]float64, len(s))
+	referenceLogX := math.Log(s[0].X)
+	var sumDeltaLogX, sumY float64
+
+	for i := 0; i < len(s); i++ {
+		if s[i].X <= 0 {
+			return nil, ErrBounds
+		}
+		logX[i] = math.Log(s[i].X)
+		sumDeltaLogX += logX[i] - referenceLogX
+		sumY += s[i].Y
+	}
+	meanDeltaLogX := sumDeltaLogX / float64(len(s))
+	meanY := sumY / float64(len(s))
+
+	var covariance, variance float64
+	for i, coordinate := range s {
+		dx := logX[i] - referenceLogX - meanDeltaLogX
+		covariance += dx * (coordinate.Y - meanY)
+		variance += dx * dx
+	}
+	if variance == 0 {
+		return nil, ErrBounds
+	}
+	a := covariance / variance
 
 	for j := 0; j < len(s); j++ {
 		regressions = append(regressions, Coordinate{
 			X: s[j].X,
-			Y: b + a*math.Log(s[j].X),
+			Y: meanY + a*(logX[j]-referenceLogX-meanDeltaLogX),
 		})
 	}
 

--- a/regression_test.go
+++ b/regression_test.go
@@ -2,10 +2,33 @@ package stats_test
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/montanaflynn/stats"
 )
+
+func assertRegressionY(
+	t *testing.T,
+	regression func(stats.Series) (stats.Series, error),
+	data stats.Series,
+	expected []float64,
+	tolerance float64,
+) {
+	t.Helper()
+	result, err := regression(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != len(expected) {
+		t.Fatalf("got %d results, expected %d", len(result), len(expected))
+	}
+	for i, coordinate := range result {
+		if math.IsNaN(coordinate.Y) || math.IsInf(coordinate.Y, 0) || math.Abs(coordinate.Y-expected[i]) > tolerance {
+			t.Errorf("result[%d].Y = %v, expected %v", i, coordinate.Y, expected[i])
+		}
+	}
+}
 
 func ExampleLinearRegression() {
 	data := []stats.Coordinate{
@@ -16,7 +39,7 @@ func ExampleLinearRegression() {
 
 	r, _ := stats.LinearRegression(data)
 	fmt.Println(r)
-	// Output: [{1 2.400000000000001} {2 3.1} {3 3.7999999999999994}]
+	// Output: [{1 2.4} {2 3.1} {3 3.8000000000000003}]
 }
 
 func TestLinearRegression(t *testing.T) {
@@ -33,8 +56,8 @@ func TestLinearRegression(t *testing.T) {
 	if !close(r[0].Y, a) {
 		t.Errorf("%v != %v", r[0].Y, a)
 	}
-	a = 3.0800000000000014
-	if !veryclose(r[1].Y, a) {
+	a = 3.08
+	if r[1].Y != a {
 		t.Errorf("%v != %v", r[1].Y, a)
 	}
 	a = 3.7800000000000002
@@ -54,6 +77,11 @@ func TestLinearRegression(t *testing.T) {
 	if err == nil {
 		t.Errorf("Empty slice should have returned an error")
 	}
+}
+
+func TestLinearRegressionWithLargeXOffset(t *testing.T) {
+	data := stats.Series{{1e9, 1}, {1e9 + 1, 2}, {1e9 + 2, 3}}
+	assertRegressionY(t, stats.LinearRegression, data, []float64{1, 2, 3}, 1e-12)
 }
 
 func TestExponentialRegression(t *testing.T) {
@@ -93,6 +121,11 @@ func TestExponentialRegression(t *testing.T) {
 	}
 }
 
+func TestExponentialRegressionWithLargeXOffset(t *testing.T) {
+	data := stats.Series{{1e9, 1}, {1e9 + 1, 2}, {1e9 + 2, 4}}
+	assertRegressionY(t, stats.ExponentialRegression, data, []float64{1, 2, 4}, 1e-12)
+}
+
 func TestExponentialRegressionYCoordErr(t *testing.T) {
 	c := []stats.Coordinate{{1, -5}, {4, 25}, {6, 5}}
 	_, err := stats.ExponentialRegression(c)
@@ -115,7 +148,7 @@ func TestLogarithmicRegression(t *testing.T) {
 	if !close(r[0].Y, a) {
 		t.Errorf("%v != %v", r[0].Y, a)
 	}
-	a = 3.3305559222492214
+	a = 3.33055592224922
 	if !veryclose(r[1].Y, a) {
 		t.Errorf("%v != %v", r[1].Y, a)
 	}
@@ -127,7 +160,7 @@ func TestLogarithmicRegression(t *testing.T) {
 	if !veryclose(r[3].Y, a) {
 		t.Errorf("%v != %v", r[3].Y, a)
 	}
-	a = 4.888413396683663
+	a = 4.888413396683665
 	if !veryclose(r[4].Y, a) {
 		t.Errorf("%v != %v", r[4].Y, a)
 	}
@@ -135,5 +168,47 @@ func TestLogarithmicRegression(t *testing.T) {
 	_, err := stats.LogarithmicRegression([]stats.Coordinate{})
 	if err == nil {
 		t.Errorf("Empty slice should have returned an error")
+	}
+}
+
+func TestLogarithmicRegressionWithLargeLogOffset(t *testing.T) {
+	data := stats.Series{
+		{math.Exp(700), 1},
+		{math.Exp(700.000001), 2},
+		{math.Exp(700.000002), 3},
+	}
+	assertRegressionY(t, stats.LogarithmicRegression, data, []float64{1, 2, 3}, 1e-7)
+}
+
+func TestRegressionsRejectInvalidDomains(t *testing.T) {
+	type regression func(stats.Series) (stats.Series, error)
+	tests := []struct {
+		name       string
+		regression regression
+		data       stats.Series
+		expected   error
+	}{
+		{"linear single point", stats.LinearRegression, stats.Series{{2, 7}}, stats.ErrBounds},
+		{"linear constant x", stats.LinearRegression, stats.Series{{2, 1}, {2, 3}, {2, 5}}, stats.ErrBounds},
+		{"exponential zero y issue 31", stats.ExponentialRegression, stats.Series{{1, 0}, {2, 3.3}}, stats.ErrYCoord},
+		{"exponential single point", stats.ExponentialRegression, stats.Series{{2, 7}}, stats.ErrBounds},
+		{"exponential constant x", stats.ExponentialRegression, stats.Series{{2, 1}, {2, 3}, {2, 5}}, stats.ErrBounds},
+		{"logarithmic zero x", stats.LogarithmicRegression, stats.Series{{0, 1}, {2, 3.3}}, stats.ErrBounds},
+		{"logarithmic negative x", stats.LogarithmicRegression, stats.Series{{-1, 1}, {2, 3.3}}, stats.ErrBounds},
+		{"logarithmic later zero x", stats.LogarithmicRegression, stats.Series{{1, 1}, {0, 3.3}}, stats.ErrBounds},
+		{"logarithmic single point", stats.LogarithmicRegression, stats.Series{{2, 7}}, stats.ErrBounds},
+		{"logarithmic constant x", stats.LogarithmicRegression, stats.Series{{2, 1}, {2, 3}, {2, 5}}, stats.ErrBounds},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			regressions, err := test.regression(test.data)
+			if err != test.expected {
+				t.Fatalf("expected %v, got %v", test.expected, err)
+			}
+			if regressions != nil {
+				t.Fatalf("expected no regressions, got %v", regressions)
+			}
+		})
 	}
 }


### PR DESCRIPTION
All three regression functions build normal equations from raw moments. That loses the variance term
when X has a large offset: a line with X around `1e9` and slope `+1` is currently fitted with a negative
slope, while the equivalent exponential fit returns only NaNs. Logarithmic regression has the same
problem in log-X space.

This rewrites the three fits using centered covariance and variance. Exponential regression keeps its
existing Y-weighted fit, but centers X before accumulating and evaluates the centered exponent directly.
The formulas are mathematically equivalent for ordinary inputs without subtracting large raw moments.

The same pass makes invalid domains explicit instead of returning successful NaN series:

- complete the fix for #31 by rejecting Y=0 as well as negative Y;
- reject non-positive X in logarithmic regression;
- return `ErrBounds` when any regression has fewer than two distinct X values.

The regression matrix covers all three large-offset failures plus nine invalid-domain combinations.
Existing regression and NIST tests remain green; two old expected values were updated because they pinned
the less accurate raw-moment rounding path.

Tests: `go test -race -coverprofile=coverage.txt -covermode=atomic`
