### PR TITLE
fix: normal tail collapses to 0/-Inf past ~8 sigma

### DIFF
--- a/norm.go
+++ b/norm.go
@@ -51,27 +51,53 @@ func NormPdf(x float64, loc float64, scale float64) float64 {
 
 // NormLogPdf is the log of the probability density function.
 func NormLogPdf(x float64, loc float64, scale float64) float64 {
-	return math.Log((math.Pow(math.E, -(math.Pow(x-loc, 2))/(2*math.Pow(scale, 2)))) / (scale * math.Sqrt(2*math.Pi)))
+	z := (x - loc) / scale
+	return -0.5*z*z - math.Log(scale) - 0.5*math.Log(2*math.Pi)
 }
 
 // NormCdf is the cumulative distribution function.
 func NormCdf(x float64, loc float64, scale float64) float64 {
-	return 0.5 * (1 + math.Erf((x-loc)/(scale*math.Sqrt(2))))
+	return 0.5 * math.Erfc(-(x-loc)/(scale*math.Sqrt2))
 }
 
 // NormLogCdf is the log of the cumulative distribution function.
 func NormLogCdf(x float64, loc float64, scale float64) float64 {
-	return math.Log(0.5 * (1 + math.Erf((x-loc)/(scale*math.Sqrt(2)))))
+	z := (x - loc) / scale
+	if z > 0 {
+		return math.Log1p(-0.5 * math.Erfc(z/math.Sqrt2))
+	}
+	return normLogTail(-z)
 }
 
 // NormSf is the survival function (also defined as 1 - cdf, but sf is sometimes more accurate).
 func NormSf(x float64, loc float64, scale float64) float64 {
-	return 1 - 0.5*(1+math.Erf((x-loc)/(scale*math.Sqrt(2))))
+	return 0.5 * math.Erfc((x-loc)/(scale*math.Sqrt2))
 }
 
 // NormLogSf is the log of the survival function.
 func NormLogSf(x float64, loc float64, scale float64) float64 {
-	return math.Log(1 - 0.5*(1+math.Erf((x-loc)/(scale*math.Sqrt(2)))))
+	z := (x - loc) / scale
+	if z < 0 {
+		return math.Log1p(-0.5 * math.Erfc(-z/math.Sqrt2))
+	}
+	return normLogTail(z)
+}
+
+// normSmallestNormal is the smallest positive normal float64; below it math.Erfc
+// keeps only a handful of significant bits.
+const normSmallestNormal = 2.2250738585072014e-308
+
+// normLogTail returns log(sf(z)) for z >= 0.
+func normLogTail(z float64) float64 {
+	if q := 0.5 * math.Erfc(z/math.Sqrt2); q >= normSmallestNormal {
+		return math.Log(q)
+	}
+	// math.Erfc has decayed into the subnormals, so switch to the Mills ratio
+	// expansion sf(z) = pdf(z)/z * (1 - 1/z^2 + 3/z^4 - 15/z^6 + 105/z^8 - ...),
+	// whose first dropped term is below 1e-12 this far out.
+	r := 1 / (z * z)
+	return -0.5*z*z - math.Log(z) - 0.5*math.Log(2*math.Pi) +
+		math.Log1p(r*(-1+r*(3+r*(-15+r*105))))
 }
 
 // NormPpf is the point percentile function.
@@ -225,11 +251,10 @@ func NormStd(loc float64, scale float64) float64 {
 
 // NormInterval finds endpoints of the range that contains alpha percent of the distribution.
 func NormInterval(alpha float64, loc float64, scale float64) [2]float64 {
-	q1 := (1.0 - alpha) / 2
-	q2 := (1.0 + alpha) / 2
-	a := NormPpf(q1, loc, scale)
-	b := NormPpf(q2, loc, scale)
-	return [2]float64{a, b}
+	// Derive both endpoints from the lower tail: (1+alpha)/2 rounds to 1 once
+	// alpha is within an ulp of it, which sends the upper endpoint to +Inf.
+	z := NormPpf((1.0-alpha)/2, 0, 1)
+	return [2]float64{loc + scale*z, loc - scale*z}
 }
 
 // factorial is the naive factorial algorithm.

--- a/norm_test.go
+++ b/norm_test.go
@@ -99,6 +99,101 @@ func TestNormLogSf(t *testing.T) {
 	}
 }
 
+// normTailRef holds reference values for the standard normal at |z| where the
+// 0.5*(1+Erf(z)) and 1-cdf forms lose the result to cancellation. Computed with
+// an 80 digit evaluation of erfc(z/sqrt(2))/2; sf is 0 where it underflows.
+var normTailRef = []struct {
+	z, sf, logSf, logPdf float64
+}{
+	{8, 6.220960574271784e-16, -35.01343715991455, -32.918938533204674},
+	{9, 1.1285884059538405e-19, -43.628149113332114, -41.418938533204674},
+	{10, 7.619853024160525e-24, -53.23128515051247, -50.918938533204674},
+	{20, 2.7536241186062337e-89, -203.91715537109727, -200.91893853320468},
+	{30, 4.906713927148187e-198, -454.3212439563432, -450.91893853320465},
+	{37, 5.725571222524577e-300, -689.0305855768906, -685.4189385332047},
+	{100, 0, -5005.524208694205, -5000.918938533205},
+	{1000, 0, -500007.82669481216, -500000.9189385332},
+}
+
+func TestNormTail(t *testing.T) {
+	for _, c := range normTailRef {
+		if got := stats.NormSf(c.z, 0, 1); !tolerance(got, c.sf, 1e-12) {
+			t.Errorf("NormSf(%v), got %v, want %v", c.z, got, c.sf)
+		}
+		if got := stats.NormCdf(-c.z, 0, 1); !tolerance(got, c.sf, 1e-12) {
+			t.Errorf("NormCdf(%v), got %v, want %v", -c.z, got, c.sf)
+		}
+		if got := stats.NormLogSf(c.z, 0, 1); !tolerance(got, c.logSf, 1e-12) {
+			t.Errorf("NormLogSf(%v), got %v, want %v", c.z, got, c.logSf)
+		}
+		if got := stats.NormLogCdf(-c.z, 0, 1); !tolerance(got, c.logSf, 1e-12) {
+			t.Errorf("NormLogCdf(%v), got %v, want %v", -c.z, got, c.logSf)
+		}
+		if got := stats.NormLogPdf(-c.z, 0, 1); !tolerance(got, c.logPdf, 1e-12) {
+			t.Errorf("NormLogPdf(%v), got %v, want %v", -c.z, got, c.logPdf)
+		}
+	}
+}
+
+// The near side of each pair is the one that used to be computed as 1-cdf.
+func TestNormTailNearOne(t *testing.T) {
+	if got, want := stats.NormCdf(8, 0, 1), 0.9999999999999993; got != want {
+		t.Errorf("NormCdf(8), got %v, want %v", got, want)
+	}
+	if got, want := stats.NormLogCdf(8, 0, 1), -6.220960574271786e-16; !tolerance(got, want, 1e-12) {
+		t.Errorf("NormLogCdf(8), got %v, want %v", got, want)
+	}
+	if got, want := stats.NormLogSf(-10, 0, 1), -7.619853024160525e-24; !tolerance(got, want, 1e-12) {
+		t.Errorf("NormLogSf(-10), got %v, want %v", got, want)
+	}
+}
+
+func TestNormCdfSfSymmetry(t *testing.T) {
+	for x := -40.0; x <= 40.0; x += 0.25 {
+		if a, b := stats.NormCdf(-x, 0, 1), stats.NormSf(x, 0, 1); a != b {
+			t.Errorf("NormCdf(%v) = %v, NormSf(%v) = %v", -x, a, x, b)
+		}
+		if a, b := stats.NormLogCdf(-x, 0, 1), stats.NormLogSf(x, 0, 1); a != b {
+			t.Errorf("NormLogCdf(%v) = %v, NormLogSf(%v) = %v", -x, a, x, b)
+		}
+		if sum := stats.NormCdf(x, 0, 1) + stats.NormSf(x, 0, 1); !veryclose(sum, 1) {
+			t.Errorf("NormCdf(%v) + NormSf(%v) = %v, want 1", x, x, sum)
+		}
+	}
+}
+
+// loc and scale only enter through z, so the tail has to survive them too.
+func TestNormTailScaled(t *testing.T) {
+	if got, want := stats.NormCdf(-50, 5, 5), 1.9106595744986757e-28; !tolerance(got, want, 1e-12) {
+		t.Errorf("NormCdf(-50, 5, 5), got %v, want %v", got, want)
+	}
+	if got, want := stats.NormSf(60, 5, 5), 1.9106595744986757e-28; !tolerance(got, want, 1e-12) {
+		t.Errorf("NormSf(60, 5, 5), got %v, want %v", got, want)
+	}
+	if got, want := stats.NormLogCdf(-50, 5, 5), -63.82493409442372; !tolerance(got, want, 1e-12) {
+		t.Errorf("NormLogCdf(-50, 5, 5), got %v, want %v", got, want)
+	}
+	if got, want := stats.NormLogPdf(-50, 5, 5), -63.02837644563877; !tolerance(got, want, 1e-12) {
+		t.Errorf("NormLogPdf(-50, 5, 5), got %v, want %v", got, want)
+	}
+}
+
+func TestNormIntervalSymmetry(t *testing.T) {
+	for _, alpha := range []float64{0.5, 0.9, 0.99, 1 - 1e-8, 1 - 1e-15} {
+		iv := stats.NormInterval(alpha, 0, 1)
+		if math.IsInf(iv[0], 0) || math.IsInf(iv[1], 0) {
+			t.Errorf("NormInterval(%v, 0, 1) = %v, want finite endpoints", alpha, iv)
+		}
+		if iv[0] != -iv[1] {
+			t.Errorf("NormInterval(%v, 0, 1) = %v, want symmetric endpoints", alpha, iv)
+		}
+		want := [2]float64{3 + 2*iv[0], 3 + 2*iv[1]}
+		if got := stats.NormInterval(alpha, 3, 2); !close(got[0], want[0]) || !close(got[1], want[1]) {
+			t.Errorf("NormInterval(%v, 3, 2) = %v, want %v", alpha, got, want)
+		}
+	}
+}
+
 func TestNormMoment(t *testing.T) {
 	if stats.NormMoment(4, 0, 1) != 3 {
 		t.Error("Input 3, Expected 3")
@@ -136,8 +231,8 @@ func TestNormFit(t *testing.T) {
 }
 
 func TestNormInterval(t *testing.T) {
-	if !reflect.DeepEqual(stats.NormInterval(0.5, 0, 1), [2]float64{-0.6744897501960818, 0.674489750196082}) {
-		t.Error("Input (50 % ), Expected {-0.6744897501960818, 0.674489750196082}")
+	if !reflect.DeepEqual(stats.NormInterval(0.5, 0, 1), [2]float64{-0.6744897501960818, 0.6744897501960818}) {
+		t.Error("Input (50 % ), Expected {-0.6744897501960818, 0.6744897501960818}")
 	}
 }
 

--- a/ztest_test.go
+++ b/ztest_test.go
@@ -26,6 +26,21 @@ func TestZTestOneSample(t *testing.T) {
 	}
 }
 
+func TestZTestLargeZ(t *testing.T) {
+	// NormSf underflowed past about 8.24 sigma, so the p-value came back as
+	// exactly 0 for any effect larger than that.
+	z, p, err := stats.ZTest(stats.Float64Data{2.5, 2.5, 2.5, 2.5}, nil, 0, 0.5)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if z != 10 {
+		t.Errorf("z statistic: got %v, want 10", z)
+	}
+	if want := 1.523970604832105e-23; !tolerance(p, want, 1e-12) {
+		t.Errorf("p-value: got %v, want %v", p, want)
+	}
+}
+
 func TestZTestTwoSample(t *testing.T) {
 	data1 := stats.Float64Data{5.1, 5.5, 4.8, 5.2, 5.0}
 	data2 := stats.Float64Data{4.2, 4.8, 4.0, 4.5, 4.3}


### PR DESCRIPTION
`norm.go` builds every tail quantity out of `0.5*(1+Erf(z))`. Once `Erf(z)` reaches -1 that sum is pure cancellation, and the whole family goes with it:

```go
stats.NormSf(8, 0, 1)       // 6.661338147750939e-16, true 6.220960574271784e-16 (7.1% high)
stats.NormSf(9, 0, 1)       // 0,    true 1.1285884059538405e-19
stats.NormCdf(-9, 0, 1)     // 0
stats.NormLogSf(9, 0, 1)    // -Inf, true -43.628149113332114
stats.NormLogPdf(-40, 0, 1) // -Inf, true -800.9189385332047
```

`NormSf` is exactly 0 from x = +8.2441 on and `NormCdf` from x = -8.3744 on, with `NormLogSf`/`NormLogCdf` at -Inf from the same points — even though the true cdf stays representable out to ±38.5 and the log forms stay finite for any finite z. `ZTest` reports its p-value as `2*NormSf(math.Abs(z), 0, 1)`, so any effect past 8.24 sigma comes back as `p == 0`.

It isn't only the far tail. Relative error of `NormSf`:

| z | before | after |
|---|---|---|
| 3 | 6.6e-15 | 8.4e-16 |
| 5 | 2.3e-10 | 2.4e-15 |
| 6 | 5.6e-8 | 3.3e-15 |
| 7 | 4.1e-5 | 1.3e-16 |
| 8 | 7.1e-2 | 5.7e-15 |
| >=9 | 1 (returns 0) | ~1e-14 |

The fix is `math.Erfc`, which is exact in both tails and is already used in this file — `NormPpf` computes `0.5*math.Erfc(-x/math.Sqrt2)` for its refinement step, so the correct form was sitting a few lines below the broken one.

- `NormCdf` / `NormSf` → `0.5*math.Erfc(∓z/math.Sqrt2)`.
- `NormLogCdf` / `NormLogSf` → `Log(Erfc)` on the far side, `Log1p(-Erfc)` on the near side. The near side was the other half of the same bug: `NormLogCdf(8)` was 7% off for exactly the same reason. Past ~37.5 sigma `math.Erfc` itself decays into the subnormals, so those two fall back to the Mills ratio expansion, which is accurate to ~1e-16 out to z = 1e150.
- `NormLogPdf` → the closed form `-z²/2 - log(scale) - log(2π)/2`, instead of logging a pdf that has already underflowed.
- `NormInterval` → both endpoints from the lower tail. `(1+alpha)/2` rounds to 1 once alpha is within an ulp of it, which sent the upper endpoint to +Inf; at alpha = 1-1e-15 it was already 0.18% off while the lower endpoint was exact.

The same defect also broke the reflection identity `NormCdf(-x) == NormSf(x)`, which fails from |x| = 0.75 upward on master and now holds bit-for-bit.

**One existing test value changes.** `TestNormInterval`'s upper endpoint moves from `0.674489750196082` to `0.6744897501960818`. The true 75th percentile is 0.674489750196081743, so the new value is 1 ulp out instead of 3, and the interval is now exactly symmetric about `loc`. Every other exact-equality assertion in `norm_test.go` is untouched and still passes bit-for-bit.

Two things I measured and deliberately left alone:

- `NormPdf` is up to 690 ulp off in the tail, but that comes from rounding z² inside the exponent, not from the `math.Pow(math.E, ...)` spelling. Substituting `math.Exp` only moves the worst case to 490 ulp and shifts two pinned values that currently hold the correctly rounded double, so it isn't worth doing without a double-double split.
- `NormPpf`'s ~1e-9 tail accuracy is inherent to Acklam's rational approximation plus one Halley step.

Reference values in the new tests come from an 80 digit evaluation of `erfc(z/sqrt2)/2`, cross-checked against direct quadrature of the density (they agree to 60 digits). `go test -race` passes and statement coverage stays at 100%.

Unrelated to the above, but noticed while going through the file: `NormIsf` ignores `loc`. It returns `-NormPpf(p, loc, scale)` where it should return `NormPpf(1-p, loc, scale)`, so `NormIsf(0.025, 100, 15)` gives -70.6 instead of 129.4 and `NormSf(NormIsf(p, loc, scale), loc, scale)` doesn't round-trip. Happy to send that as a separate PR if you'd like it fixed.
