### PR TITLE
fix: NormIsf ignores loc, NormPpf uncorrected above the median

### DIFF
--- a/norm.go
+++ b/norm.go
@@ -158,7 +158,15 @@ func NormPpf(p float64, loc float64, scale float64) (x float64) {
 			(((((b1*r+b2)*r+b3)*r+b4)*r+b5)*r + 1)
 	}
 
-	e := 0.5*math.Erfc(-x/math.Sqrt2) - p
+	// Halley correction on cdf(x)-p. Above the median cdf(x) and p have both
+	// already rounded to 1, so the difference is taken between the survival
+	// functions instead; 1-p is exact for p >= 0.5.
+	var e float64
+	if p > 0.5 {
+		e = (1 - p) - 0.5*math.Erfc(x/math.Sqrt2)
+	} else {
+		e = 0.5*math.Erfc(-x/math.Sqrt2) - p
+	}
 	u := e * math.Sqrt(2*math.Pi) * math.Exp(x*x/2)
 	x = x - u/(1+x*u/2)
 
@@ -166,11 +174,10 @@ func NormPpf(p float64, loc float64, scale float64) (x float64) {
 }
 
 // NormIsf is the inverse survival function (inverse of sf).
-func NormIsf(p float64, loc float64, scale float64) (x float64) {
-	if -NormPpf(p, loc, scale) == 0 {
-		return 0
-	}
-	return -NormPpf(p, loc, scale)
+func NormIsf(p float64, loc float64, scale float64) float64 {
+	// isf(p) == ppf(1-p), reached by reflecting the standard normal so that
+	// loc stays out of the negation and 1-p is never formed.
+	return loc - scale*NormPpf(p, 0, 1)
 }
 
 // NormMoment approximates the non-central (raw) moment of order n.

--- a/norm_test.go
+++ b/norm_test.go
@@ -194,6 +194,88 @@ func TestNormIntervalSymmetry(t *testing.T) {
 	}
 }
 
+// NormIsf negated the whole affine result, so loc came back with the wrong
+// sign. Only loc == 0 was ever exercised, where -ppf(p) happens to be right.
+func TestNormIsfLocScale(t *testing.T) {
+	if got, want := stats.NormIsf(0.025, 100, 15), 129.39945976810083; !veryclose(got, want) {
+		t.Errorf("NormIsf(0.025, 100, 15), got %v, want %v", got, want)
+	}
+	for _, loc := range []float64{0, 1, -1, 0.5, -3.25, 100, -100} {
+		for _, scale := range []float64{1, 2, 0.5, 15, 0.1} {
+			for _, p := range []float64{1e-300, 1e-8, 0.001, 0.025, 0.1, 0.4, 0.5, 0.6, 0.9, 1 - 1e-8} {
+				if got, want := stats.NormIsf(p, loc, scale), loc+scale*stats.NormIsf(p, 0, 1); got != want {
+					t.Errorf("NormIsf(%v, %v, %v), got %v, want %v", p, loc, scale, got, want)
+				}
+			}
+		}
+	}
+}
+
+func TestNormIsfEdges(t *testing.T) {
+	if got := stats.NormIsf(0, 5, 2); !math.IsInf(got, 1) {
+		t.Errorf("NormIsf(0, 5, 2), got %v, want +Inf", got)
+	}
+	if got := stats.NormIsf(1, 5, 2); !math.IsInf(got, -1) {
+		t.Errorf("NormIsf(1, 5, 2), got %v, want -Inf", got)
+	}
+	if got := stats.NormIsf(1.5, 0, 1); !math.IsNaN(got) {
+		t.Errorf("NormIsf(1.5, 0, 1), got %v, want NaN", got)
+	}
+	if got, want := stats.NormIsf(1e-300, 0, 1), 37.047096299361201; !veryclose(got, want) {
+		t.Errorf("NormIsf(1e-300, 0, 1), got %v, want %v", got, want)
+	}
+}
+
+// Above the median the Halley correction differenced cdf(x) and p after both
+// had rounded to 1, leaving the raw Acklam estimate uncorrected.
+var normPpfUpperRef = []struct{ p, x float64 }{
+	{0.75, 0.67448975019608171},
+	{0.9, 1.2815515655446006},
+	{0.99, 2.3263478740408408},
+	{0.999, 3.0902323061678132},
+	{1 - 1e-6, 4.7534243088170873},
+	{1 - 1e-9, 5.9978070196016375},
+	{1 - 1e-12, 7.0344869100478356},
+	{1 - 1e-15, 7.9414444874159784},
+}
+
+func TestNormPpfUpperTail(t *testing.T) {
+	for _, c := range normPpfUpperRef {
+		if got := stats.NormPpf(c.p, 0, 1); !veryclose(got, c.x) {
+			t.Errorf("NormPpf(%v), got %v, want %v", c.p, got, c.x)
+		}
+	}
+}
+
+// Driven from the upper half so that 1-q is exact and the two sides really are
+// complementary probabilities.
+func TestNormPpfReflection(t *testing.T) {
+	for _, q := range []float64{0.5, 0.51, 0.6, 0.75, 0.9, 0.99, 0.999, 1 - 1e-6,
+		1 - 1e-9, 1 - 1e-12, 1 - 1e-15, math.Nextafter(1, 0)} {
+		if got, want := stats.NormPpf(q, 0, 1), -stats.NormPpf(1-q, 0, 1); !veryclose(got, want) {
+			t.Errorf("NormPpf(%v) = %v, -NormPpf(%v) = %v", q, got, 1-q, want)
+		}
+		if got, want := stats.NormIsf(q, 0, 1), stats.NormPpf(1-q, 0, 1); !veryclose(got, want) {
+			t.Errorf("NormIsf(%v) = %v, NormPpf(%v) = %v", q, got, 1-q, want)
+		}
+	}
+}
+
+func TestNormQuantileRoundTrip(t *testing.T) {
+	for _, loc := range []float64{0, -2.5, 100} {
+		for _, scale := range []float64{1, 0.1, 15} {
+			for _, p := range []float64{1e-300, 1e-100, 1e-8, 0.025, 0.3, 0.5, 0.7, 0.975, 1 - 1e-8} {
+				if got := stats.NormSf(stats.NormIsf(p, loc, scale), loc, scale); !tolerance(got, p, 1e-11) {
+					t.Errorf("NormSf(NormIsf(%v, %v, %v)), got %v, want %v", p, loc, scale, got, p)
+				}
+				if got := stats.NormCdf(stats.NormPpf(p, loc, scale), loc, scale); !tolerance(got, p, 1e-11) {
+					t.Errorf("NormCdf(NormPpf(%v, %v, %v)), got %v, want %v", p, loc, scale, got, p)
+				}
+			}
+		}
+	}
+}
+
 func TestNormMoment(t *testing.T) {
 	if stats.NormMoment(4, 0, 1) != 3 {
 		t.Error("Input 3, Expected 3")


### PR DESCRIPTION
**`NormIsf` ignores `loc`.** It returns `-NormPpf(p, loc, scale)`, which negates `loc` along with the quantile, so the result is off by `2*loc`:

```go
stats.NormIsf(0.025, 100, 15)                         // -70.60054023189919, want 129.39945976810083
stats.NormSf(stats.NormIsf(0.025, 100, 15), 100, 15)  // 1, want 0.025
```

It is correct only at `loc == 0`, where `-ppf(p) == ppf(1-p)` by symmetry — the only case the tests covered. Fixed by reflecting the standard normal, `loc - scale*NormPpf(p, 0, 1)`. The simpler-looking `NormPpf(1-p, loc, scale)` does not work: `1-p` rounds to 1 for small `p` and `NormIsf(1e-300, 0, 1)` would become `+Inf`.

**`NormPpf` goes uncorrected above the median.** Its Halley step forms `cdf(x)-p`, and past about `1-1e-8` both terms have already rounded to 1, so the residual is exactly 0 and the raw Acklam estimate survives — `NormPpf(1-1e-12, 0, 1)` returns `7.0344869026843035` against `7.0344869100478356`, roughly 8.3 million ulp. Differencing the survival functions instead removes the cancellation, and `1-p` is exact for `p >= 0.5`.

I checked the other 17 `loc`/`scale` functions against the affine contract (`f(loc+scale*z, loc, scale)` versus the standard-normal value transformed); `NormIsf` was the only one that failed.

Tests use reference values from a 120-digit mpmath oracle cross-checked against quadrature of the density: the affine invariant over a `loc`×`scale`×`p` grid, `Sf(Isf(p)) == p`, `Cdf(Ppf(p)) == p`, and `NormPpf(q) == -NormPpf(1-q)` driven from the upper half so `1-q` is exact. `go test -race` passes, coverage stays at 100%, and no existing expected value changes.
