### PR TITLE
docs: PercentileOfScore matches scipy kind="mean", not kind="rank"

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -970,7 +970,7 @@ relative to a slice of floats, defined as the percentage of
 values strictly below the score plus half the percentage of
 values equal to the score. The result is between 0 and 100.
 This matches the behavior of Python's
-scipy.stats.percentileofscore with kind="rank".
+scipy.stats.percentileofscore with kind="mean".
 
 
 

--- a/percentile_of_score.go
+++ b/percentile_of_score.go
@@ -7,7 +7,7 @@ import "math"
 // values strictly below the score plus half the percentage of
 // values equal to the score. The result is between 0 and 100.
 // This matches the behavior of Python's
-// scipy.stats.percentileofscore with kind="rank".
+// scipy.stats.percentileofscore with kind="mean".
 func PercentileOfScore(input Float64Data, score float64) (float64, error) {
 	if input.Len() == 0 {
 		return math.NaN(), ErrEmptyInput


### PR DESCRIPTION
Was porting some numbers off scipy and couldn't work out why they didn't line up. The comment on `PercentileOfScore` says it matches `scipy.stats.percentileofscore` with `kind="rank"`, but the formula is scipy's `kind="mean"` (checked against scipy 1.18.0):

```python
>>> scipy.stats.percentileofscore([1, 2, 3, 4], 3, kind="rank")
75.0
>>> scipy.stats.percentileofscore([1, 2, 3, 4], 3, kind="mean")
62.5
```

`ExamplePercentileOfScore` asserts 62.5 for that exact input, so it's the label that's off rather than the code. The two kinds only differ when the score is present in the data, which makes it easy to miss.

Left the code alone on purpose - the prose in the same comment already describes `mean`, and changing it would break the example plus the eight cases in `TestPercentileOfScore`. Happy to go the other way instead if you'd rather, just say.

`DOCUMENTATION.md` has the same sentence so it's changed there too. That file's generated by `make docs`, so drop the hunk if you'd sooner regenerate it.
