### PR TITLE
fix: reject NaN in Interp xp and propagate NaN in x

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -536,6 +536,7 @@ fp[len(xp)-1], so no extrapolation is performed. Unlike numpy's interp,
 which silently returns nonsense for unsorted coordinates, xp must be
 strictly increasing or ErrBounds is returned. An empty x or xp returns
 ErrEmptyInput and xp and fp of different lengths return ErrSize.
+A NaN in xp returns ErrBounds and a NaN in x gives a NaN in the output.
 
 
 

--- a/interp.go
+++ b/interp.go
@@ -1,6 +1,9 @@
 package stats
 
-import "sort"
+import (
+	"math"
+	"sort"
+)
 
 // Interp calculates the one-dimensional piecewise-linear interpolant to a
 // function with given discrete data points (xp, fp), evaluated at each x.
@@ -9,6 +12,7 @@ import "sort"
 // which silently returns nonsense for unsorted coordinates, xp must be
 // strictly increasing or ErrBounds is returned. An empty x or xp returns
 // ErrEmptyInput and xp and fp of different lengths return ErrSize.
+// A NaN in xp returns ErrBounds and a NaN in x gives a NaN in the output.
 func Interp(x, xp, fp Float64Data) ([]float64, error) {
 
 	if x.Len() == 0 || xp.Len() == 0 {
@@ -19,8 +23,9 @@ func Interp(x, xp, fp Float64Data) ([]float64, error) {
 		return nil, ErrSize
 	}
 
-	for i := 1; i < xp.Len(); i++ {
-		if xp[i] <= xp[i-1] {
+	// NaN loses every comparison, so the ordering check can't catch it
+	for i := 0; i < xp.Len(); i++ {
+		if math.IsNaN(xp[i]) || (i > 0 && xp[i] <= xp[i-1]) {
 			return nil, ErrBounds
 		}
 	}
@@ -29,6 +34,8 @@ func Interp(x, xp, fp Float64Data) ([]float64, error) {
 
 	for i, xv := range x {
 		switch {
+		case math.IsNaN(xv):
+			output[i] = math.NaN()
 		case xv <= xp[0]:
 			output[i] = fp[0]
 		case xv >= xp[xp.Len()-1]:

--- a/interp_test.go
+++ b/interp_test.go
@@ -2,6 +2,7 @@ package stats_test
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"testing"
 
@@ -50,10 +51,23 @@ func TestInterpInvalidInput(t *testing.T) {
 		{[]float64{1.5}, []float64{1, 2}, []float64{10}, stats.ErrSize},
 		{[]float64{1.5}, []float64{2, 1}, []float64{10, 20}, stats.ErrBounds},
 		{[]float64{1.5}, []float64{1, 1}, []float64{10, 20}, stats.ErrBounds},
+		{[]float64{1.5}, []float64{1, math.NaN(), 3}, []float64{10, 20, 30}, stats.ErrBounds},
+		{[]float64{1.5}, []float64{math.NaN()}, []float64{10}, stats.ErrBounds},
 	} {
 		_, err := stats.Interp(c.x, c.xp, c.fp)
 		if err != c.err {
 			t.Errorf("Interp(%.1f, %.1f, %.1f) => %v != %v", c.x, c.xp, c.fp, err, c.err)
 		}
+	}
+}
+
+func TestInterpNaNInput(t *testing.T) {
+	x := []float64{1.5, math.NaN(), 2.5}
+	got, err := stats.Interp(x, []float64{1, 2, 3}, []float64{10, 20, 30})
+	if err != nil {
+		t.Fatalf("Returned an error: %v", err)
+	}
+	if got[0] != 15 || !math.IsNaN(got[1]) || got[2] != 25 {
+		t.Errorf("Interp(%v, ...) => %v != [15 NaN 25]", x, got)
 	}
 }


### PR DESCRIPTION
`Interp` panics on a NaN. v0.12.3:

```go
stats.Interp([]float64{math.NaN()}, []float64{1, 2, 3}, []float64{10, 20, 30})
// panic: runtime error: index out of range [3] with length 3
```

Hit it putting sensor readings through a calibration curve, some of them NaN.

A NaN in `xp` gets past the strictly-increasing check too, so `Interp([]float64{1.5}, []float64{1, math.NaN(), 3}, ...)` comes back with a number and a nil error where the doc comment promsies `ErrBounds`.

Not sure about the `x` side. I've got it propagating the NaN into the output the way numpy does, since it's one output per input and erroring the whole call throws away every other point - but `ErrNaN` is a fair reading too and thats your call.

`DOCUMENTATION.md` is hand-edited rather than regenerated, `make docs` moves a load of unrelated line offsets on current master.
