### PR TITLE
fix: reject NaN percent in Percentile and PercentileNearestRank

### DIFF
--- a/percentile.go
+++ b/percentile.go
@@ -27,7 +27,7 @@ func Percentile(input Float64Data, percent float64) (percentile float64, err err
 		return input[0], nil
 	}
 
-	if percent <= 0 || percent > 100 {
+	if math.IsNaN(percent) || percent <= 0 || percent > 100 {
 		return math.NaN(), BoundsErr
 	}
 
@@ -62,8 +62,8 @@ func PercentileNearestRank(input Float64Data, percent float64) (percentile float
 		return math.NaN(), EmptyInputErr
 	}
 
-	// Return error for less than 0 or greater than 100 percentages
-	if percent < 0 || percent > 100 {
+	// Return error for NaN, less than 0, or greater than 100 percentages
+	if math.IsNaN(percent) || percent < 0 || percent > 100 {
 		return math.NaN(), BoundsErr
 	}
 

--- a/percentile_test.go
+++ b/percentile_test.go
@@ -1,6 +1,7 @@
 package stats_test
 
 import (
+	"math"
 	"reflect"
 	"testing"
 
@@ -46,6 +47,10 @@ func TestPercentile(t *testing.T) {
 	_, err = stats.Percentile([]float64{1, 2, 3, 4, 5}, 101)
 	if err != stats.BoundsErr {
 		t.Errorf("Too high percent didn't return expected error; got %v", err)
+	}
+	_, err = stats.Percentile([]float64{1, 2, 3, 4, 5}, math.NaN())
+	if err != stats.BoundsErr {
+		t.Errorf("NaN percent didn't return expected error; got %v", err)
 	}
 }
 
@@ -161,6 +166,11 @@ func TestPercentileNearestRank(t *testing.T) {
 	_, err = stats.PercentileNearestRank([]float64{1, 2, 3, 4, 5}, 110)
 	if err == nil {
 		t.Errorf("Should have returned an percentage must not be above 100 error")
+	}
+
+	_, err = stats.PercentileNearestRank([]float64{1, 2, 3, 4, 5}, math.NaN())
+	if err != stats.BoundsErr {
+		t.Errorf("NaN percentage didn't return expected error; got %v", err)
 	}
 
 }


### PR DESCRIPTION
## Summary

A NaN `percent` argument evades the existing bounds checks in `Percentile` and `PercentileNearestRank` because every comparison against NaN is false. The NaN then flows into `int(rank)` / `int(math.Ceil(...))`, whose result for NaN is architecture-dependent:

- **amd64**: `int(NaN)` is a huge negative number, so indexing panics with index out of range
- **arm64**: `int(NaN)` is 0, so `Percentile` returns `NaN` with a **nil error** and `PercentileNearestRank` silently returns the minimum value

## Fix

Fold `math.IsNaN(percent)` into the existing bounds validation so a NaN percent returns `ErrBounds`, the same as any other out-of-range percent.

## Testing

- Added invalid-input rows asserting `ErrBounds` for NaN percent in both functions
- `go test -cover .` stays at 100.0% of statements; `go vet` and `gofmt` clean

Related: same bug class in `PercentileWeighted` is fixed separately in a follow-up PR.