### PR TITLE
fix: reject NaN percent in PercentileWeighted

### DIFF
--- a/percentile_weighted.go
+++ b/percentile_weighted.go
@@ -26,7 +26,7 @@ func PercentileWeighted(data, weights Float64Data, percent float64) (percentile 
 		return math.NaN(), ErrSize
 	}
 
-	if percent <= 0 || percent > 100 {
+	if math.IsNaN(percent) || percent <= 0 || percent > 100 {
 		return math.NaN(), ErrBounds
 	}
 

--- a/percentile_weighted_test.go
+++ b/percentile_weighted_test.go
@@ -105,6 +105,11 @@ func TestPercentileWeightedInvalidPercent(t *testing.T) {
 	if err != stats.ErrBounds {
 		t.Errorf("expected ErrBounds for percent=-5, got %v", err)
 	}
+
+	_, err = stats.PercentileWeighted(data, weights, math.NaN())
+	if err != stats.ErrBounds {
+		t.Errorf("expected ErrBounds for percent=NaN, got %v", err)
+	}
 }
 
 func TestPercentileWeightedNegativeWeight(t *testing.T) {


### PR DESCRIPTION
## Summary

A NaN `percent` argument evades the bounds checks in `PercentileWeighted` because every comparison against NaN is false. The cumulative-weight target then becomes NaN, so `cumWeight >= target` never matches and the function falls through to its initial value — silently returning the **maximum** data value with a nil error:

```go
stats.PercentileWeighted([]float64{1, 2, 3}, []float64{1, 1, 1}, math.NaN())
// before: 3, nil — after: NaN, ErrBounds
```

## Fix

Fold `math.IsNaN(percent)` into the existing bounds validation so a NaN percent returns `ErrBounds`, the same as any other out-of-range percent.

## Testing

- Added a NaN row to `TestPercentileWeightedInvalidPercent`
- `go test -cover .` stays at 100.0% of statements; `go vet` and `gofmt` clean

Related: #130 fixes the same bug class in `Percentile` and `PercentileNearestRank`, where it can panic on amd64.